### PR TITLE
fermenter: improve input items processing.

### DIFF
--- a/tubelib_addons1/fermenter.lua
+++ b/tubelib_addons1/fermenter.lua
@@ -91,17 +91,31 @@ local function convert_leaves_to_biogas(meta)
 	local inv = meta:get_inventory()
 	local biogas = ItemStack("tubelib_addons1:biogas")
 	if inv:room_for_item("dst", biogas) then					-- enough output space?
-		local items = tubelib.get_num_items(meta, "src", 2)
-		if items then											-- input available?
-			if is_leaves(items:get_name()) then
-				inv:add_item("dst", biogas)
-				return true
+		local items = {}
+		local fault = false
+		for i = 1, 2 do
+			items[i] = tubelib.get_num_items(meta, "src", 1)
+			if items[i] then						-- input available?
+				if not is_leaves(items[i]:get_name()) then
+					fault = true
+					break
+				end
 			else
-				inv:add_item("src", items)
-				return nil  -- error
+				break
 			end
+		end
+		if #items == 2 then
+			inv:add_item("dst", biogas)
+			return true
 		else
-			return false  -- standby
+			for i = 1, #items do
+				inv:add_item("src", items[i])
+			end
+			if fault then
+				return nil  -- error
+			else
+				return false  -- standby
+			end
 		end
 	else
 		return false  -- standby


### PR DESCRIPTION
Change source item pulling logic: previously 2 leaves items
were taken at once from the same stack, so only identical types
were used to produce Biogas (remaining single items could fill
up source tray). Now items are taken one by one, allowing 2
different plant leaves to form 1 Biogas unit. That cleans up
inventory as well - maximum one item is left there when production
ends.

Signed-off-by: Michal Cieslakiewicz <michal.cieslakiewicz@wp.pl>