### PR TITLE
Gravelsieve fixes

### DIFF
--- a/gravelsieve/init.lua
+++ b/gravelsieve/init.lua
@@ -89,10 +89,10 @@ local function add_ores()
 	end
 	local overall_probability = 0.0
 	for name,probability in pairs(gravelsieve.ore_probability) do
-		print(string.format("[gravelsieve] %-32s %u", name, probability))
+		minetest.log("info", string.format("[gravelsieve] %-32s %u", name, probability))
 		overall_probability = overall_probability + 1.0/probability
 	end
-	print(string.format("[gravelsieve] Overall probability %g", overall_probability))
+	minetest.log("info", string.format("[gravelsieve] Overall probability %g", overall_probability))
 end	
 
 minetest.after(1, add_ores)

--- a/gravelsieve/init.lua
+++ b/gravelsieve/init.lua
@@ -70,6 +70,7 @@ local function add_ores()
 			and drop ~= item.ore
 			and drop ~= ""
 			and item.ore_type == "scatter"
+			and item.wherein == "default:stone"
 			and item.clust_scarcity ~= nil and item.clust_scarcity > 0 
 			and item.clust_size ~= nil and item.clust_size > 0 then
 				local probability = item.clust_scarcity / item.clust_size / 

--- a/gravelsieve/init.lua
+++ b/gravelsieve/init.lua
@@ -72,17 +72,14 @@ local function add_ores()
 			and item.ore_type == "scatter"
 			and item.wherein == "default:stone"
 			and item.clust_scarcity ~= nil and item.clust_scarcity > 0 
-			and item.clust_size ~= nil and item.clust_size > 0 then
-				local probability = item.clust_scarcity / item.clust_size / 
-								PROBABILITY_FACTOR * gravelsieve.ore_rarity
-				probability = math.floor(probability)
-				if probability > 20 then
-					if gravelsieve.ore_probability[drop] == nil then
-						gravelsieve.ore_probability[drop] = probability
-					else
-						gravelsieve.ore_probability[drop] = 
-										math.min(gravelsieve.ore_probability[drop], probability)
-					end
+			and item.clust_num_ores ~= nil and item.clust_num_ores > 0 
+			and item.y_max ~= nil and item.y_min ~= nil then
+				local probability = (gravelsieve.ore_rarity / PROBABILITY_FACTOR) * item.clust_scarcity / (item.clust_num_ores * ((item.y_max - item.y_min) / 65535))
+				if gravelsieve.ore_probability[drop] == nil then
+					gravelsieve.ore_probability[drop] = probability
+				else
+					-- harmonic sum
+					gravelsieve.ore_probability[drop] = 1.0 / ((1.0 / gravelsieve.ore_probability[drop]) + (1.0 / probability))
 				end
 			end
 		end


### PR DESCRIPTION
Hello,

There's some bugginess w/ how the gravel sieve determines how likely a given ore is to appear, and this PR is an attempt to resolve that. It is, however, coded against the stable v1.16 tag and not the in-development 2.0 "master" branch. 

This patch has been tested w/ the non-default ore-generating mods that are installed on the only server i play on, namely, terumet, titanium, moreores, and quartz. 

The main differences:
1) Instead of using "clust_size", which indicates the spatial dimensions of an ore vein, it makes use of "clust_num_ores", which indicates how many of the nodes in a vein will actually be occupied by ore, no matter what its size.
2) It only checks for ores that occur in "default:stone"; this is to account for ores like terumetal-in-desert-stone, which is a rare occurrence off the world surface, but ends up dominating that ore's generation in practice w/ the existing code. 
3) It deals w/ ores which define different ore-generation statistics on different elevations, through two methods: 
 a) It scales the probability by the levels that the ore is generated on ((item.y_max - item.y_min) / 65535).
 b) It sums the probabilities of ore generated on different levels, instead of just looking at the level on which the ore is most likely. 

Minor differences:
1) I've changed "print" statements into "minetest.log" statements.
2) I stopped ignoring probabilities greater than 1 in 20.

Caveats:
1) I don't know how this will react w/ mods other than the ones I've mentioned, particularly the "only in default:stone" requirement. 
2) I don't know how important the "probabilities greater than 1 in 20" requirement is; I have no idea what happens if e.g. the sum likelihood of finding an ore is greater than 1. I feel like this check would more logically go elsewhere, though, if it's even really needed.

Testing which was done:
I launched a single player world w/ this change + a bunch of other mods and counted what showed up after sieving. It appeared roughly to correspond to what I expected, though I didn't do any rigorous statistical tests on this. 

Results:

These are the raw 1/x probabilities output from the "mintest.log" statements. These values correspond much more to my intuitive ideas of which ores are most likely after spending a few dozen hours mining. Also, the total chance of any ore coming out of the sieve remains @ about 1 in 6.

| Version | Coal | Diamond | Mese | Quartz | Titanium | Iron | Gold | Copper | Tin | Terumetal | Silver | Mithril | Overall |
| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
| v1.16 | 56 | 375 | 304 | 66 | 1365 | 38 | 244 | 81 | 111 | 22 | 40 | 40 | 0.167279 |
| this PR | 20 | 303 | 197 | 117 | 1213 | 21 | 157 | 52 | 71 | 209 | 234 | 953 | 0.162336 |

Afterword:

I welcome any comments or suggestions on this PR. I feel like i'm mostly doing this for posterity, as you're in the middle of a major re-write of the code, and I don't know if this change will be applicable. It's possible I'll be able to get my server admins to directly apply this diff before the next update is released.