### PR TITLE
Fixes for Blocky Survival

### DIFF
--- a/tubelib/node_states.lua
+++ b/tubelib/node_states.lua
@@ -305,7 +305,7 @@ function NodeStates:keep_running(pos, meta, val, num_items)
 	if self.aging_level1 then
 		local cnt = meta:get_int("tubelib_aging") + num_items
 		meta:set_int("tubelib_aging", cnt)
-		if (cnt > (self.aging_level1) and math.random(self.aging_level2/num_items) == 1)
+		if (cnt > (self.aging_level1) and math.random(math.max(1, math.floor(self.aging_level2/num_items))) == 1)
 		or cnt >= 999999 then
 			self:defect(pos, meta)
 		end
@@ -431,7 +431,7 @@ end
 function NodeStates:after_dig_node(pos, oldnode, oldmetadata, digger)
 	local inv = minetest.get_inventory({type="player", name=digger:get_player_name()})
 	local cnt = oldmetadata.fields.tubelib_aging and tonumber(oldmetadata.fields.tubelib_aging) or 0
-	local is_defect = cnt > self.aging_level1 and math.random(self.aging_level2 / cnt) == 1
+	local is_defect = cnt > self.aging_level1 and math.random(math.max(1, math.floor(self.aging_level2 / cnt))) == 1
 	if self.node_name_defect and is_defect then
 		inv:add_item("main", ItemStack(self.node_name_defect))
 	else

--- a/tubelib_addons1/quarry.lua
+++ b/tubelib_addons1/quarry.lua
@@ -36,8 +36,10 @@ local Level2Idx = {[2]=1, [1]=2, [0]=3, [-1]=4, [-2]=5, [-3]=6,
 				   [-5]=7, [-10]=8, [-15]=9, [-20]=10}
 
 local function formspec(self, pos, meta)
-	local depth = meta:get_int("max_levels") or 1
-	local start_level = meta:get_int("start_level") or 1
+	local depth = meta:get_int("max_levels")
+	if not Depth2Idx[depth] then depth = 1 end
+	local start_level = meta:get_int("start_level")
+	if not Level2Idx[start_level] then start_level = 0 end
 	local endless = meta:get_int("endless") or 0
 	local fuel = meta:get_int("fuel") or 0
 	-- some recalculations


### PR DESCRIPTION
We're having serious issues w/ tubelib crashes on Blocky Survival. So far as I know, there are two causes:

1) A quarry that was placed with a node replacement tool, which crashes the server as soon as it is loaded (by a player coming in proximity of it). This is because meta:get_int(...) is assumed to return nil if the value isn't defined, but instead it returns 0. 0 is not a legal quarry dig depth, so Depth2Idx[depth] is nil, and hence we get a string concatenation error. I have provided code to ensure that the depth (and max level) values are defined. I have not been able to test this fix on BlS because I can find no way to hot-patch the quarry state's formspec function, but it doesn't seem to cause any issues on my local server. 

2) Whenever a player breaks a tubelib machine that is defective (or on the verge of becoming defective), the server also crashes, due to "self.aging_level2 / cnt" not being an integer, or possibly being 0. I cannot replicate this issue on another world, but I can verify that hot-patching techpack on BlS with this fix (which ensures that the argument to random is an integer > 0) resolves the issue without apparent problems.

This is includes a fix for https://github.com/joe7575/techpack/issues/14