### PR TITLE
Further gravelsieve distribution tweaks

### DIFF
--- a/gravelsieve/mod.conf
+++ b/gravelsieve/mod.conf
@@ -1,1 +1,4 @@
 name=gravelsieve
+description=This mod includes a hammer to produce gravel from Cobblestone and a sieve to sift gravel to find ores.
+depends=default
+optional_depends=moreblocks,tubelib,hopper,pipeworks

--- a/gravelsieve/settingtypes.txt
+++ b/gravelsieve/settingtypes.txt
@@ -1,5 +1,7 @@
 # Rarity factor to find ores when sieving with the Gravel Sieve
-# 1.0 is according to the mapgen generator 
+# 1.0 is according to the mapgen generator
 # 2.0 means half as many ores as result
 # 0.5 means twice as many ores as result
-gravelsieve_ore_rarity (Rarity factor to find ores) float 1.5
+gravelsieve_ore_rarity (Rarity factor to find ores) float 1.16
+gravelsieve_ore_max_elevation (Maximum elevation considered when calculating ore distribution) int 0 -30912 30927
+gravelsieve_ore_min_elevation (Minimum elevation considered when calculating ore distribution) int -30912 -30912 30927


### PR DESCRIPTION
This is a further revision of the work I did in pull request #9 . 

After noticing that the relative rarity of ores output from the gravel sieve still didn't match what I was seeing empirically, I did some further digging (in source code, and literally mining), and noticed that one of the major sources of the mismatch was that the default ores were registered to occur between y levels (elevations) between +1024 and +31000. This had the effect of making the non-default ores, which had no such setting, about half as common as they should have been. 

My solution is to introduce a couple of new configurable settings for the gravelsieve: a maximum and a minimum elevation to consider when calculating ore ore distribution probabilities. I have set the defaults of these to be 0 and -30912, which seems sensible. 

I also did a little bit of cleanup on the relevant calculation code, to make it easier to read. 

My "empirical" test was to dig 3 columns straight down from elevation 0 to the bottom of the map.
Here is a table of the old, current, proposed, and empirical values I have. The values of the empirical tests have been scaled to match the occurrence of coal in my newly proposed values. 

| Version | coal | iron | copper | tin | gold | mese | diamond | silver | mithril | terumetal | quartz | titanium | total prob |
| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
| v1.16 | 56 | 38 | 81 | 111 | 244 | 304 | 375 | 40 | 40 | 22 | 66 | 1365 | 0.167279 |
| current | 20 | 21 | 52 | 71 | 157 | 197 | 303 | 234 | 953 | 209 | 117 | 1213 | 0.162336 |
| this PR | 22.3 | 23.2 | 56.6 | 77.7 | 173 | 220 | 345 | 129 | 525 | 111 | 64.5 | 694 | 0.167445 |
| emp. min | 22.3 | 22.1 | 58.1 | 86.2 | 170 | 207 | 269 | 105 | 478 | 120 | 77.7 | 584 | N/A |
| emp. avg | 22.3 | 25.6 | 62 | 99 | 182 | 227 | 302 | 129 | 568 | 134 | 78.2 | 852 | N/A |
| emp. max | 22.3 | 27 | 68.1 | 111 | 197 | 250 | 360 | 144 | 663 | 159 | 79.7 | 1420 | N/A |

The values are still noticeably off in a few places, but overall it is much more accurate. 