### PR TITLE
Let quarry dig obsidian

### DIFF
--- a/tubelib_addons1/nodes.lua
+++ b/tubelib_addons1/nodes.lua
@@ -18,8 +18,8 @@ tubelib_addons1.Flowers = {}
 
 -- table needed for Grinder
 tubelib_addons1.GroundNodes = {}
-	
-	
+
+
 -- default trees which require the node timer
 function tubelib_addons1.register_tree_node(name, drop, plant)
 	tubelib_addons1.FarmingNodes[name] = {drop = drop or name, plant = plant, t1= 166, t2 = 288}
@@ -161,6 +161,7 @@ gn("default:silver_sand")
 gn("default:ice")
 gn("default:snowblock")
 gn("default:snow")
+gn("default:obsidian")
 
 gn("stairs:stair_cobble")
 gn("stairs:stair_mossycobble")


### PR DESCRIPTION
I don't know if this was intentional or an oversight, but the quarry doesn't currently dig obsidian. As I've recently lobbied Terumoc to close the obsidian-duping loop in Terumet (https://github.com/Terumoc/terumet/pull/23) on the assumption that the quarry dug obsidian, I'm asking for this to be included in base Techpack. Otherwise, I'll continue to add this behaviour on our server through an override mod.