### PR TITLE
Disallow non-fuel items to be accepted as fuel quarries and harvesters

### DIFF
--- a/tubelib_addons1/harvester.lua
+++ b/tubelib_addons1/harvester.lua
@@ -117,7 +117,7 @@ local function allow_metadata_inventory_put(pos, listname, index, stack, player)
 	local inv = M(pos):get_inventory()
 	if listname == "main" then
 		return stack:get_count()
-	elseif listname == "fuel" and stack:get_name() == "tubelib_addons1:biofuel" then
+	elseif listname == "fuel" and tubelib.is_fuel(stack) then
 		return stack:get_count()
 	end
 	return 0
@@ -178,7 +178,12 @@ end
 -- check the fuel level and return false if empty
 local function check_fuel(pos, this, meta)
 	if this.fuel <= 0 then
-		if tubelib.get_this_item(meta, "fuel", 1) == nil then
+		local fuel_item = tubelib.get_this_item(meta, "fuel", 1)
+		if fuel_item == nil then
+			return false
+		end
+		if not tubelib.is_fuel(fuel_item) then
+			tubelib.put_item(meta, "fuel", fuel_item)
 			return false
 		end
 		this.fuel = BURNING_TIME
@@ -431,6 +436,9 @@ tubelib.register_node("tubelib_addons1:harvester_base", {"tubelib_addons1:harves
 		return tubelib.get_item(M(pos), "main")
 	end,
 	on_push_item = function(pos, side, item)
+		if not tubelib.is_fuel(item) then
+			return false
+		end
 		return tubelib.put_item(M(pos), "fuel", item)
 	end,
 	on_unpull_item = function(pos, side, item)

--- a/tubelib_addons1/quarry.lua
+++ b/tubelib_addons1/quarry.lua
@@ -119,7 +119,7 @@ local function allow_metadata_inventory_put(pos, listname, index, stack, player)
 	local inv = M(pos):get_inventory()
 	if listname == "main" then
 		return stack:get_count()
-	elseif listname == "fuel" and stack:get_name() == "tubelib_addons1:biofuel" then
+	elseif listname == "fuel" and tubelib.is_fuel(stack) then
 		return stack:get_count()
 	end
 	return 0
@@ -161,8 +161,14 @@ local function quarry_next_node(pos, meta)
 	-- check fuel
 	local fuel = meta:get_int("fuel") or 0
 	if fuel <= 0 then
-		if tubelib.get_this_item(meta, "fuel", 1) == nil then
+		local fuel_item = tubelib.get_this_item(meta, "fuel", 1)
+		if fuel_item == nil then
 			State:fault(pos, meta)
+			return
+		end
+		if not tubelib.is_fuel(fuel_item) then
+			State:fault(pos, meta)
+			tubelib.put_item(meta, "fuel", fuel_item)
 			return
 		end
 		fuel = BURNING_TIME
@@ -439,6 +445,9 @@ tubelib.register_node("tubelib_addons1:quarry",
 		return tubelib.get_item(M(pos), "main")
 	end,
 	on_push_item = function(pos, side, item)
+		if not tubelib.is_fuel(item) then
+			return false
+		end
 		return tubelib.put_item(M(pos), "fuel", item)
 	end,
 	on_unpull_item = function(pos, side, item)

--- a/tubelib_addons1/reformer.lua
+++ b/tubelib_addons1/reformer.lua
@@ -340,6 +340,9 @@ minetest.register_craft({
 	},
 })
 
+function tubelib.is_fuel(stack)
+	return stack:get_name() == "tubelib_addons1:biofuel"
+end
 
 tubelib.register_node("tubelib_addons1:reformer", {"tubelib_addons1:reformer_defect"}, {
 	on_pull_item = function(pos, side)


### PR DESCRIPTION
Fixes BLS issue 258 https://github.com/BlockySurvival/issue-tracker/issues/258

This adds a new `is_fuel` function in the reformer code for better configurability if the way fuel works is changed in the future (like to accept more items as fuel)

More importantly it uses that function to disallow non-fuel items to be burned as fuel.

This can currently be achieved by pushing non-fuel items into the slot with a pusher, the items can then be burned just like fuel.

The solution here is two-fold:
* It checks the item it's trying to burn is actually fuel, and puts it back if it isn't
* It checks if the item being pushed in is fuel, and disallows pushing if it is not

This means that anyone who already has non-fuel items in their fuel slot will not be able to burn that as fuel, but will also mean they can no longer push non-fuel items in.