### PR TITLE
Add a on_blast callback to tubes so they update after being destroyed

### DIFF
--- a/tubelib/tubes.lua
+++ b/tubelib/tubes.lua
@@ -32,6 +32,15 @@ local Tube = tubelib2.Tube:new({
 
 tubelib.Tube = Tube
 
+local function ON_BLAST(id)
+	return function (pos)
+		local node = minetest.get_node(pos)
+        minetest.remove_node(pos)
+		Tube:after_dig_tube(pos, node)
+		return {id}
+	end
+end
+
 minetest.register_node("tubelib:tubeS", {
 	description = "Tubelib Tube",
 	tiles = { -- Top, base, right, left, front, back
@@ -77,6 +86,7 @@ minetest.register_node("tubelib:tubeS", {
 	is_ground_content = false,
 	groups = {choppy=2, cracky=3},
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = ON_BLAST("tubelib:tubeS"),
 })
 
 minetest.register_node("tubelib:tubeA", {
@@ -118,6 +128,7 @@ minetest.register_node("tubelib:tubeA", {
 	groups = {choppy=2, cracky=3, not_in_creative_inventory=1},
 	sounds = default.node_sound_wood_defaults(),
 	drop = "tubelib:tubeS",
+	on_blast = ON_BLAST("tubelib:tubeA"),
 })
 
 minetest.register_craft({

--- a/tubelib/tubes.lua
+++ b/tubelib/tubes.lua
@@ -35,7 +35,7 @@ tubelib.Tube = Tube
 local function ON_BLAST(id)
 	return function (pos)
 		local node = minetest.get_node(pos)
-        minetest.remove_node(pos)
+		minetest.remove_node(pos)
 		Tube:after_dig_tube(pos, node)
 		return {id}
 	end


### PR DESCRIPTION
Fixes BLS issue 254 https://github.com/BlockySurvival/issue-tracker/issues/254

Implementation of on_blast seen here
https://github.com/Terumoc/terumet/blob/f7b9e01187d5b44d0c50b7bd291cd76ad9cfbad9/terumet/material/tglass.lua#L22
and the function that calls, here
https://github.com/Terumoc/terumet/blob/f7b9e01187d5b44d0c50b7bd291cd76ad9cfbad9/terumet/init.lua#L51

All this does is provide the same update that digging a tube will, but when destroying a tube with TNT

In the broken state, blowing up tubes will not break their connection (until the game is restarted)
In the fixed state (this code), blowing up the tubes will make the output tube the last one in the line