### PR TITLE
Check harvester protection for each node it attempts to harvest

### DIFF
--- a/tubelib_addons1/harvester.lua
+++ b/tubelib_addons1/harvester.lua
@@ -216,6 +216,9 @@ local function harvest_field(this, meta)
 	end
 	for y_pos = start_y_pos,stop_y_pos,-1 do
 		pos.y = y_pos
+		if minetest.is_protected(pos, this.owner) then
+			return true
+		end
 		local node = minetest.get_node_or_nil(pos)
 		if node and node.name ~= "air" then
 			local order = tubelib_addons1.FarmingNodes[node.name] or tubelib_addons1.Flowers[node.name]

--- a/tubelib_addons1/harvester.lua
+++ b/tubelib_addons1/harvester.lua
@@ -216,14 +216,11 @@ local function harvest_field(this, meta)
 	end
 	for y_pos = start_y_pos,stop_y_pos,-1 do
 		pos.y = y_pos
-		if minetest.is_protected(pos, this.owner) then
-			return true
-		end
 		local node = minetest.get_node_or_nil(pos)
 		if node and node.name ~= "air" then
 			local order = tubelib_addons1.FarmingNodes[node.name] or tubelib_addons1.Flowers[node.name]
 			if order then
-				if not remove_or_replace_node(this, pos, inv, node, order) then
+				if not minetest.is_protected(pos, this.owner) and not remove_or_replace_node(this, pos, inv, node, order) then
 					return false
 				end
 			else 	


### PR DESCRIPTION
Fixes BLS issue 186 https://github.com/BlockySurvival/issue-tracker/issues/186

Performs protection check for each node it attempts to harvest, and exits as soon as it sees a protected node.

Considering there is a protection check outside of the for loop, I have a feeling this wasn't done for efficiency reasons. It would be nice if we could ask if a volume is protected, not just a node, but currently this code is required for security reasons.

One odd feature of this change is that nodes above a protected area will be harvested, but nodes below that protected area will not. I don't think that's such an issue, but we could:
- Loop through the nodes checking for any protection before removing anything, skipping the entire thing if anything is protected
- Skip this iteration of harvesting instead of exiting the function, so that harvest would resume below the protected area