### PR TITLE
Suggestion to check replanting against commonly plantable nodes instead of quarry-able GroundNodes

### DIFF
--- a/tubelib_addons1/harvester.lua
+++ b/tubelib_addons1/harvester.lua
@@ -145,6 +145,16 @@ local function remove_all_sapling_items(pos)
 	end
 end
 
+local function is_plantable_ground(node)
+	if minetest.get_item_group(node.name, "soil") ~= 0 then
+		return true
+	end
+	if minetest.get_item_group(node.name, "sand") ~= 0 then
+		return true
+	end
+	return false
+end
+
 -- Remove wood/leave nodes and place sapling if necessary
 -- Return false if inventory is full
 -- else return true
@@ -161,7 +171,7 @@ local function remove_or_replace_node(this, pos, inv, node, order)
 		minetest.remove_node(pos)
 		inv:add_item("main", ItemStack(order.drop))
 		this.num_items = this.num_items + 1
-		if tubelib_addons1.GroundNodes[next_node.name] ~= nil and order.plant then  -- hit the ground?
+		if is_plantable_ground(next_node) and order.plant then  -- hit the ground?
 			minetest.set_node(pos, {name=order.plant, paramtype2 = "wallmounted", param2=1})
 			if order.t1 ~= nil then 
 				-- We have to simulate "on_place" and start the timer by hand


### PR DESCRIPTION
Fixes BLS issue 265 https://github.com/BlockySurvival/issue-tracker/issues/265

This is a suggestion, and I do not believe the behaviour is a bug, since it doesn't have any real negative effects, is rarely encountered, and can easily be worked around

This PR does not check the `tubelib1.GroundNodes` table for nodes when deciding weather or not to replant a tree / flower / crop, instead it checks if the node is in `group:soil` or `group:sand` (for palm trees).

Checking these groups should cover most cases, while not also allowing saplings to be replanted on other quarry-able ground nodes, like stone, ores, and clay