### PR TITLE
Perform warehouse push action on unpull, and stop removing things from the cache on unpull

### DIFF
--- a/techpack_warehouse/box_copper.lua
+++ b/techpack_warehouse/box_copper.lua
@@ -130,7 +130,7 @@ tubelib.register_node(NODE_NAME,
 	on_push_item = function(pos, side, item)
 		local meta = M(pos)
 		meta:set_string("push_dir", wh.Turn180[side])
-		local num = wh.numbers_to_shift(Box, meta, item)
+		local num = wh.inv_add_item(Box, meta, item)
 		if num > 0 then
 			item:set_count(num)
 			return tubelib.put_item(meta, "shift", item)
@@ -145,7 +145,7 @@ tubelib.register_node(NODE_NAME,
 	end,
 	on_unpull_item = function(pos, side, item)
 		local meta = M(pos)
-		local num = wh.numbers_to_shift(Box, meta, item)
+		local num = wh.inv_add_item(Box, meta, item)
 		if num > 0 then
 			-- this should never happen, but better safe than sorry
 			item:set_count(num)

--- a/techpack_warehouse/box_copper.lua
+++ b/techpack_warehouse/box_copper.lua
@@ -144,7 +144,14 @@ tubelib.register_node(NODE_NAME,
 		return tubelib.get_item(M(pos), "main")
 	end,
 	on_unpull_item = function(pos, side, item)
-		return tubelib.put_item(M(pos), "main", item)
+		local meta = M(pos)
+		local num = wh.numbers_to_shift(Box, meta, item)
+		if num > 0 then
+			-- this should never happen, but better safe than sorry
+			item:set_count(num)
+			return tubelib.put_item(meta, "shift", item)
+		end
+		return true
 	end,
 
 	on_recv_message = function(pos, topic, payload)

--- a/techpack_warehouse/box_gold.lua
+++ b/techpack_warehouse/box_gold.lua
@@ -130,7 +130,7 @@ tubelib.register_node(NODE_NAME,
 	on_push_item = function(pos, side, item)
 		local meta = M(pos)
 		meta:set_string("push_dir", wh.Turn180[side])
-		local num = wh.numbers_to_shift(Box, meta, item)
+		local num = wh.inv_add_item(Box, meta, item)
 		if num > 0 then
 			item:set_count(num)
 			return tubelib.put_item(meta, "shift", item)
@@ -145,7 +145,7 @@ tubelib.register_node(NODE_NAME,
 	end,
 	on_unpull_item = function(pos, side, item)
 		local meta = M(pos)
-		local num = wh.numbers_to_shift(Box, meta, item)
+		local num = wh.inv_add_item(Box, meta, item)
 		if num > 0 then
 			-- this should never happen, but better safe than sorry
 			item:set_count(num)

--- a/techpack_warehouse/box_gold.lua
+++ b/techpack_warehouse/box_gold.lua
@@ -144,7 +144,14 @@ tubelib.register_node(NODE_NAME,
 		return tubelib.get_item(M(pos), "main")
 	end,
 	on_unpull_item = function(pos, side, item)
-		return tubelib.put_item(M(pos), "main", item)
+		local meta = M(pos)
+		local num = wh.numbers_to_shift(Box, meta, item)
+		if num > 0 then
+			-- this should never happen, but better safe than sorry
+			item:set_count(num)
+			return tubelib.put_item(meta, "shift", item)
+		end
+		return true
 	end,
 
 	on_recv_message = function(pos, topic, payload)

--- a/techpack_warehouse/box_steel.lua
+++ b/techpack_warehouse/box_steel.lua
@@ -130,7 +130,7 @@ tubelib.register_node(NODE_NAME,
 	on_push_item = function(pos, side, item)
 		local meta = M(pos)
 		meta:set_string("push_dir", wh.Turn180[side])
-		local num = wh.numbers_to_shift(Box, meta, item)
+		local num = wh.inv_add_item(Box, meta, item)
 		if num > 0 then
 			item:set_count(num)
 			return tubelib.put_item(meta, "shift", item)
@@ -145,7 +145,7 @@ tubelib.register_node(NODE_NAME,
 	end,
 	on_unpull_item = function(pos, side, item)
 		local meta = M(pos)
-		local num = wh.numbers_to_shift(Box, meta, item)
+		local num = wh.inv_add_item(Box, meta, item)
 		if num > 0 then
 			-- this should never happen, but better safe than sorry
 			item:set_count(num)

--- a/techpack_warehouse/box_steel.lua
+++ b/techpack_warehouse/box_steel.lua
@@ -144,7 +144,14 @@ tubelib.register_node(NODE_NAME,
 		return tubelib.get_item(M(pos), "main")
 	end,
 	on_unpull_item = function(pos, side, item)
-		return tubelib.put_item(M(pos), "main", item)
+		local meta = M(pos)
+		local num = wh.numbers_to_shift(Box, meta, item)
+		if num > 0 then
+			-- this should never happen, but better safe than sorry
+			item:set_count(num)
+			return tubelib.put_item(meta, "shift", item)
+		end
+		return true
 	end,
 
 	on_recv_message = function(pos, topic, payload)

--- a/techpack_warehouse/common.lua
+++ b/techpack_warehouse/common.lua
@@ -188,10 +188,8 @@ function techpack_warehouse.numbers_to_shift(self, meta, item)
 		if item_name == name then
 			local stack_size = inv:get_stack("main", idx):get_count()
 			if stack_size == self.inv_size then -- full?
-				Cache[number][idx] = "" -- delete for searching
 			elseif (stack_size + num_items) > self.inv_size then -- limit will be reached?
 				inv:set_stack("main", idx, ItemStack({name = item_name, count = self.inv_size}))
-				Cache[number][idx] = "" -- delete for searching
 				-- search with the rest for further slots
 				num_items = num_items - (self.inv_size - stack_size)
 			else

--- a/techpack_warehouse/common.lua
+++ b/techpack_warehouse/common.lua
@@ -209,7 +209,6 @@ function techpack_warehouse.allow_metadata_inventory_put(self, pos, listname, in
 	if listname == "input" and item_name == stack:get_name() then
 		return math.min(stack:get_count(), self.inv_size - main_stack:get_count())
 	elseif listname == "filter" and item_name == main_stack:get_name() then
-		local number = M(pos):get_string("tubelib_number")
 		return 1
 	elseif listname == "shift" then
 		return stack:get_count()
@@ -219,7 +218,6 @@ end
 
 function techpack_warehouse.on_metadata_inventory_put(pos, listname, index, stack, player)
 	if listname == "input" then
-		local number = M(pos):get_string("tubelib_number")
 		minetest.after(0.5, move_to_main, pos, index)
 	end
 end
@@ -230,7 +228,6 @@ function techpack_warehouse.allow_metadata_inventory_take(pos, listname, index, 
 	end
 	local inv = M(pos):get_inventory()
 	local main_stack = inv:get_stack("main", index)
-	local number = M(pos):get_string("tubelib_number")
 	if listname == "main" then
 		minetest.after(0.1, move_to_player_inv, player:get_player_name(), pos, index)
 		return 0
@@ -250,7 +247,6 @@ function techpack_warehouse.on_receive_fields(self, pos, formname, fields, playe
 	if minetest.is_protected(pos, player:get_player_name()) then
 		return
 	end
-	local number = M(pos):get_string("tubelib_number")
 	self.State:state_button_event(pos, fields)
 end
 


### PR DESCRIPTION
Fixes issue #61 

I believe `tubelib.put_item` may be limiting the stack to a normal stack size, I replaced this with the same code that appears in the `on_push` code, which obviously works perfectly fine.

This change works, but introduces a new error.

I have seen tubelib, instead of pulling a stack from an inventory, pull one item from one stack, and 98 items from another, moving 99 in total, but leaving the origin inventory in an unexpected state.

This is the same for the warehouse, if you leave the two lines in this PR relating to the cache in the code, you will see some stacks be reduced by one item, and that item miraculously turn up in the last inventory slot. This is a problem if all the slots are already full, the unpull command will end up with extra items that must be put in 'shift'. This should not happen. I have also seen this lead to the disappearance of items.

If we stop removing the full stacks from cache, we check each one every time and make sure the items go back to where they came from.

The best testing scenario for this is as follows (see issue #61 for machine set up):

1. Make sure both pushers are stopped
2. Make sure the destination chest is full
3. Make sure the warehouse is full
4. Make sure you know exactly how many items are in the source chest
5. Remove a stack and a bit from the destination chest
6. Remove a stack from each of the warehouse slots
7. Put an arbitrary amount back into each warehouse slot (personally I did half a stack, then 1/4 a stack in the next one etc... this is just to stop us working with perfect stacks which may be misleadingly convenient)
8. Turn on the right most pusher, then turn on the left most pusher quickly thereafter
9. You can watch the warehouse, but what's more important is that, once it's all done (and you switch the pushers off), you take all the items, fill the destination chest back up, fill the warehouse back up, then put the rest in the source chest. If there are exactly as many as you started with in the source chest, there is no error.

I always end up with the wrong total if I let it run long enough with the cache statements left in, with them removed (as per the PR) I am unable to re-produce the error.

Frankly... I'm not 100% sure what benefit this cache is (especially since I've made it useless!) but I'm not really sure it would save THAT much time.

I'm not sure if this solves all the bugs I've seen with the warehouse, but if we get this in I can start long-term observation in the wild and can hopefully show if any issues remain.