### PR TITLE
Prevent digging of active tubelib nodes with node replacer etc.

### DIFF
--- a/techpack_warehouse/box_copper.lua
+++ b/techpack_warehouse/box_copper.lua
@@ -87,6 +87,9 @@ minetest.register_node(NODE_NAME.."_active", {
 	on_metadata_inventory_put = wh.on_metadata_inventory_put,
 	allow_metadata_inventory_take = wh.allow_metadata_inventory_take,
 	allow_metadata_inventory_move = wh.allow_metadata_inventory_move,
+  
+	diggable = false,
+	can_dig = function() return false end,
 	
 	on_rotate = screwdriver.disallow,
 	paramtype = "light",

--- a/techpack_warehouse/box_gold.lua
+++ b/techpack_warehouse/box_gold.lua
@@ -88,6 +88,9 @@ minetest.register_node(NODE_NAME.."_active", {
 	allow_metadata_inventory_take = wh.allow_metadata_inventory_take,
 	allow_metadata_inventory_move = wh.allow_metadata_inventory_move,
 	
+	diggable = false,
+	can_dig = function() return false end,
+	
 	on_rotate = screwdriver.disallow,
 	paramtype = "light",
 	sunlight_propagates = true,

--- a/techpack_warehouse/box_steel.lua
+++ b/techpack_warehouse/box_steel.lua
@@ -87,6 +87,9 @@ minetest.register_node(NODE_NAME.."_active", {
 	on_metadata_inventory_put = wh.on_metadata_inventory_put,
 	allow_metadata_inventory_take = wh.allow_metadata_inventory_take,
 	allow_metadata_inventory_move = wh.allow_metadata_inventory_move,
+  
+	diggable = false,
+	can_dig = function() return false end,
 	
 	on_rotate = screwdriver.disallow,
 	paramtype = "light",

--- a/tubelib/distributor.lua
+++ b/tubelib/distributor.lua
@@ -444,6 +444,9 @@ minetest.register_node("tubelib:distributor_active", {
 	on_timer = keep_running,
 	on_rotate = screwdriver.disallow,
 
+	diggable = false,
+	can_dig = function() return false end,
+
 	paramtype = "light",
 	sunlight_propagates = true,
 	paramtype2 = "facedir",

--- a/tubelib/pusher.lua
+++ b/tubelib/pusher.lua
@@ -174,7 +174,10 @@ minetest.register_node("tubelib:pusher_active", {
 	
 	on_timer = keep_running,
 	on_rotate = screwdriver.disallow,
-	
+
+	diggable = false,
+	can_dig = function() return false end,
+
 	paramtype = "light",
 	sunlight_propagates = true,
 	paramtype2 = "facedir",

--- a/tubelib_addons1/autocrafter.lua
+++ b/tubelib_addons1/autocrafter.lua
@@ -353,6 +353,9 @@ minetest.register_node("tubelib_addons1:autocrafter_active", {
 			},
 		},
 	},
+
+	diggable = false,
+	can_dig = function() return false end,
 	
 	on_rotate = screwdriver.disallow,
 	on_timer = keep_running,

--- a/tubelib_addons1/grinder.lua
+++ b/tubelib_addons1/grinder.lua
@@ -193,6 +193,9 @@ minetest.register_node("tubelib_addons1:grinder_active", {
 		"tubelib_front.png",
 	},
 
+	diggable = false,
+	can_dig = function() return false end,
+
 	on_rotate = screwdriver.disallow,
 	on_timer = keep_running,
 	on_receive_fields = on_receive_fields,

--- a/tubelib_addons1/liquidsampler.lua
+++ b/tubelib_addons1/liquidsampler.lua
@@ -202,6 +202,9 @@ minetest.register_node("tubelib_addons1:liquidsampler_active", {
 		'tubelib_addons1_liquidsampler.png',
 	},
 
+	diggable = false,
+	can_dig = function() return false end,
+
 	on_rotate = screwdriver.disallow,
 	on_timer = keep_running,
 	on_receive_fields = on_receive_fields,

--- a/tubelib_addons1/pusher_fast.lua
+++ b/tubelib_addons1/pusher_fast.lua
@@ -174,6 +174,9 @@ minetest.register_node("tubelib_addons1:pusher_fast_active", {
 	
 	on_timer = keep_running,
 	on_rotate = screwdriver.disallow,
+
+	diggable = false,
+	can_dig = function() return false end,
 	
 	paramtype = "light",
 	sunlight_propagates = true,

--- a/tubelib_addons1/quarry.lua
+++ b/tubelib_addons1/quarry.lua
@@ -372,6 +372,9 @@ minetest.register_node("tubelib_addons1:quarry_active", {
 	on_timer = keep_running,
 	on_rotate = screwdriver.disallow,
 
+	diggable = false,
+	can_dig = function() return false end,
+
 	allow_metadata_inventory_put = allow_metadata_inventory_put,
 	allow_metadata_inventory_take = allow_metadata_inventory_take,
 	

--- a/tubelib_addons3/distributor.lua
+++ b/tubelib_addons3/distributor.lua
@@ -413,6 +413,9 @@ minetest.register_node("tubelib_addons3:distributor_active", {
 	on_timer = keep_running,
 	on_rotate = screwdriver.disallow,
 
+	diggable = false,
+	can_dig = function() return false end,
+
 	paramtype = "light",
 	sunlight_propagates = true,
 	paramtype2 = "facedir",

--- a/tubelib_addons3/pusher.lua
+++ b/tubelib_addons3/pusher.lua
@@ -159,7 +159,10 @@ minetest.register_node("tubelib_addons3:pusher_active", {
 	
 	on_timer = keep_running,
 	on_rotate = screwdriver.disallow,
-	
+
+	diggable = false,
+	can_dig = function() return false end,
+
 	paramtype = "light",
 	sunlight_propagates = true,
 	paramtype2 = "facedir",


### PR DESCRIPTION
The replacer mod, among others, provides a way to bypass the digging protection present on active tubelib nodes (see [this forum post](https://forum.minetest.net/viewtopic.php?p=172046&sid=313844a79f6ac3eb73a03b536ddf6308#p172046).

Per discussion on #64 