### PR TITLE
Fix mesecons converter + end wrench crashing

### DIFF
--- a/tubelib_addons2/mesecons_converter.lua
+++ b/tubelib_addons2/mesecons_converter.lua
@@ -151,7 +151,7 @@ tubelib.register_node("tubelib_addons2:mesecons_converter", {}, {
 			meta:set_string("infotext", S("Tubelib Mesecons Converter").." "..own_number..S(": connected with").." "..payload)
 			meta:set_string("numbers", payload)
 			meta:set_string("formspec", formspec(meta))
+			return true
 		end
-		return true
 	end,
 })		


### PR DESCRIPTION
Punching a mesecons converter with an end wrench causes a crash because its on_receive_message function returns the wrong thing; fixed that