### PR TITLE
Disallow pushing into invalid faces

### DIFF
--- a/tubelib/command.lua
+++ b/tubelib/command.lua
@@ -403,23 +403,22 @@ function tubelib.pull_items(pos, side, player_name)
 	local npos, nside, name = get_dest_node(pos, side)
 	if npos == nil then return end
 	if tubelib_NodeDef[name] and tubelib_NodeDef[name].on_pull_item then
+		if Tube:is_valid_side(name, nside) == false then
+			return false
+		end
 		return tubelib_NodeDef[name].on_pull_item(npos, nside, player_name)
 	end
 	return nil
 end
 
+
 function tubelib.push_items(pos, side, items, player_name)
 	local npos, nside, name = get_dest_node(pos, side)
 	if npos == nil then return end
-
-	local _,node = Tube:get_node(pos)
-	local dir = side_to_dir(side, node.param2)
-	local node, _, valid = Tube:get_secondary_node(pos, dir)
-	if node and not valid then
-		return false
-	end
-
 	if tubelib_NodeDef[name] and tubelib_NodeDef[name].on_push_item then
+		if Tube:is_valid_side(name, nside) == false then
+			return false
+		end
 		return tubelib_NodeDef[name].on_push_item(npos, nside, items, player_name)
 	elseif name == "air" then
 		minetest.add_item(npos, items)
@@ -440,7 +439,11 @@ end
 function tubelib.pull_stack(pos, side, player_name)
 	local npos, nside, name = get_dest_node(pos, side)
 	if npos == nil then return end
+
 	if tubelib_NodeDef[name] then
+		if Tube:is_valid_side(name, nside) == false then
+			return false
+		end
 		if tubelib_NodeDef[name].on_pull_stack then
 			return tubelib_NodeDef[name].on_pull_stack(npos, nside, player_name)
 		elseif tubelib_NodeDef[name].on_pull_item then

--- a/tubelib/command.lua
+++ b/tubelib/command.lua
@@ -186,33 +186,13 @@ local function register_lbm(name, nodenames)
 	})
 end
 
-
-local DirToSide = {"B", "R", "F", "L", "D", "U"}
-
-local function dir_to_side(dir, param2)
-	if dir < 5 then
-		dir = (((dir - 1) - (param2 % 4)) % 4) + 1
-	end
-	return DirToSide[dir]
-end
-
-local SideToDir = {B=1, R=2, F=3, L=4, D=5, U=6}
-
-local function side_to_dir(side, param2)
-	local dir = SideToDir[side]
-	if dir < 5 then
-		dir = (((dir - 1) + (param2 % 4)) % 4) + 1
-	end
-	return dir
-end
-
 local function get_dest_node(pos, side)
 	local _,node = Tube:get_node(pos)
-	local dir = side_to_dir(side, node.param2)
+	local dir = tubelib2.side_to_dir(side, node.param2)
 	local spos, sdir = Tube:get_connected_node_pos(pos, dir)
 	if not (spos and sdir) then return end
 	_,node = Tube:get_node(spos)
-	local out_side = dir_to_side(tubelib2.Turn180Deg[sdir], node.param2)
+	local out_side = tubelib2.dir_to_side(tubelib2.Turn180Deg[sdir], node.param2)
 	return spos, out_side, Name2Name[node.name] or node.name
 end
 

--- a/tubelib/command.lua
+++ b/tubelib/command.lua
@@ -431,6 +431,14 @@ end
 function tubelib.push_items(pos, side, items, player_name)
 	local npos, nside, name = get_dest_node(pos, side)
 	if npos == nil then return end
+
+	local _,node = Tube:get_node(pos)
+	local dir = side_to_dir(side, node.param2)
+	local node, _, valid = Tube:get_secondary_node(pos, dir)
+	if node and not valid then
+		return false
+	end
+
 	if tubelib_NodeDef[name] and tubelib_NodeDef[name].on_push_item then
 		return tubelib_NodeDef[name].on_push_item(npos, nside, items, player_name)
 	elseif name == "air" then

--- a/tubelib_addons3/teleporter.lua
+++ b/tubelib_addons3/teleporter.lua
@@ -39,12 +39,9 @@ minetest.register_node("tubelib_addons3:teleporter", {
 	after_place_node = function(pos, placer)
 		tubelib.add_node(pos, "tubelib_addons3:teleporter")
 		-- determine the tube side
-		local tube_dir = ((minetest.dir_to_facedir(placer:get_look_dir()) + 1) % 4) + 1
+		local tube_dir = tubelib2.side_to_dir("R", minetest.dir_to_facedir(placer:get_look_dir()))
 		Tube:prepare_pairing(pos, tube_dir, sFormspec)
 		Tube:after_place_node(pos, {tube_dir})
-		local meta = M(pos)
-		local valid_dirs = minetest.serialize({[tube_dir]=true})
-		meta:set_string('valid_dirs', valid_dirs)
 	end,
 
 	on_receive_fields = function(pos, formname, fields, player)
@@ -78,4 +75,4 @@ minetest.register_craft({
 	},
 })
 
-Tube:add_secondary_node_names({"tubelib_addons3:teleporter"})
+Tube:add_secondary_node_names({"tubelib_addons3:teleporter"}, {B=false, R=true, F=false, L=false, D=false, U=false})


### PR DESCRIPTION
Fixes #72 

This is actually independent of ongoing discussions, as this uses `get_secondary_node` to determine validity, which will be modified by any alternate solution to the valid faces problem.

i.e. This fix should work with current and future code