### PR TITLE
Implement valid sides for other nodes

### DIFF
--- a/tubelib/blackhole.lua
+++ b/tubelib/blackhole.lua
@@ -76,7 +76,7 @@ tubelib.register_node("tubelib:blackhole", {}, {
 	on_pull_item = nil,  		-- not needed
 	on_unpull_item = nil,		-- not needed
 	
-	valid_sides = {R=false, L=true, B=false, F=false, D=false, U=false},
+	valid_sides = {"L"},
 	on_push_item = function(pos, side, item)
 		local meta = minetest.get_meta(pos)
 		local disappeared = meta:get_int("disappeared") + item:get_count()

--- a/tubelib/blackhole.lua
+++ b/tubelib/blackhole.lua
@@ -76,15 +76,13 @@ tubelib.register_node("tubelib:blackhole", {}, {
 	on_pull_item = nil,  		-- not needed
 	on_unpull_item = nil,		-- not needed
 	
+	valid_sides = {R=false, L=true, B=false, F=false, D=false, U=false},
 	on_push_item = function(pos, side, item)
-		if side == "L" then
-			local meta = minetest.get_meta(pos)
-			local disappeared = meta:get_int("disappeared") + item:get_count()
-			meta:set_int("disappeared", disappeared)
-			meta:set_string("infotext", disappeared.." "..S("items disappeared"))
-			return true		
-		end
-		return false
+		local meta = minetest.get_meta(pos)
+		local disappeared = meta:get_int("disappeared") + item:get_count()
+		meta:set_int("disappeared", disappeared)
+		meta:set_string("infotext", disappeared.." "..S("items disappeared"))
+		return true
 	end,
 	
 	on_recv_message = function(pos, topic, payload)

--- a/tubelib/pusher.lua
+++ b/tubelib/pusher.lua
@@ -238,7 +238,7 @@ tubelib.register_node("tubelib:pusher",
 	on_push_item = nil,			-- pusher has no inventory
 	on_unpull_item = nil,		-- pusher has no inventory
 	is_pusher = true,           -- is a pulling/pushing node
-	
+	valid_sides = {R=true, L=true, B=false, F=false, D=false, U=false},
 	on_recv_message = function(pos, topic, payload)
 		local resp = State:on_receive_message(pos, topic, payload)
 		if resp then

--- a/tubelib/pusher.lua
+++ b/tubelib/pusher.lua
@@ -238,7 +238,7 @@ tubelib.register_node("tubelib:pusher",
 	on_push_item = nil,			-- pusher has no inventory
 	on_unpull_item = nil,		-- pusher has no inventory
 	is_pusher = true,           -- is a pulling/pushing node
-	valid_sides = {R=true, L=true, B=false, F=false, D=false, U=false},
+	valid_sides = {"R","L"},
 	on_recv_message = function(pos, topic, payload)
 		local resp = State:on_receive_message(pos, topic, payload)
 		if resp then

--- a/tubelib_addons1/detector.lua
+++ b/tubelib_addons1/detector.lua
@@ -132,7 +132,7 @@ minetest.register_craft({
 
 
 tubelib.register_node("tubelib_addons1:detector", {"tubelib_addons1:detector_active"}, {
-	valid_sides = {R=true, L=true, B=false, F=false, D=false, U=false},
+	valid_sides = {"R","L"},
 	on_push_item = function(pos, side, item)
 		if side ~= "L" then return false end
 		local player_name = minetest.get_meta(pos):get_string("player_name")

--- a/tubelib_addons1/detector.lua
+++ b/tubelib_addons1/detector.lua
@@ -132,6 +132,7 @@ minetest.register_craft({
 
 
 tubelib.register_node("tubelib_addons1:detector", {"tubelib_addons1:detector_active"}, {
+	valid_sides = {R=true, L=true, B=false, F=false, D=false, U=false},
 	on_push_item = function(pos, side, item)
 		if side ~= "L" then return false end
 		local player_name = minetest.get_meta(pos):get_string("player_name")

--- a/tubelib_addons1/funnel.lua
+++ b/tubelib_addons1/funnel.lua
@@ -139,6 +139,7 @@ minetest.register_craft({
 
 
 tubelib.register_node("tubelib_addons1:funnel", {}, {
+	valid_sides = {U=false},
 	on_pull_item = function(pos, side)
 		local meta = minetest.get_meta(pos)
 		return tubelib.get_item(meta, "main")

--- a/tubelib_addons1/funnel.lua
+++ b/tubelib_addons1/funnel.lua
@@ -139,7 +139,7 @@ minetest.register_craft({
 
 
 tubelib.register_node("tubelib_addons1:funnel", {}, {
-	valid_sides = {U=false},
+	invalid_sides = {"U"},
 	on_pull_item = function(pos, side)
 		local meta = minetest.get_meta(pos)
 		return tubelib.get_item(meta, "main")

--- a/tubelib_addons1/liquidsampler.lua
+++ b/tubelib_addons1/liquidsampler.lua
@@ -281,7 +281,7 @@ minetest.register_craft({
 
 tubelib.register_node("tubelib_addons1:liquidsampler", 
 	{"tubelib_addons1:liquidsampler_active", "tubelib_addons1:liquidsampler_defect"}, {
-	valid_sides = {L=false},
+	invalid_sides = {"L"},
 	on_pull_item = function(pos, side)
 		return tubelib.get_item(M(pos), "dst")
 	end,

--- a/tubelib_addons1/liquidsampler.lua
+++ b/tubelib_addons1/liquidsampler.lua
@@ -281,6 +281,7 @@ minetest.register_craft({
 
 tubelib.register_node("tubelib_addons1:liquidsampler", 
 	{"tubelib_addons1:liquidsampler_active", "tubelib_addons1:liquidsampler_defect"}, {
+	valid_sides = {L=false},
 	on_pull_item = function(pos, side)
 		return tubelib.get_item(M(pos), "dst")
 	end,

--- a/tubelib_addons1/pusher_fast.lua
+++ b/tubelib_addons1/pusher_fast.lua
@@ -237,6 +237,7 @@ tubelib.register_node("tubelib_addons1:pusher_fast",
 	on_push_item = nil,			-- pusher has no inventory
 	on_unpull_item = nil,		-- pusher has no inventory
 	is_pusher = true,           -- is a pulling/pushing node
+	valid_sides = {R=true, L=true, B=false, F=false, D=false, U=false},
 	
 	on_recv_message = function(pos, topic, payload)
 		local resp = State:on_receive_message(pos, topic, payload)

--- a/tubelib_addons1/pusher_fast.lua
+++ b/tubelib_addons1/pusher_fast.lua
@@ -237,7 +237,7 @@ tubelib.register_node("tubelib_addons1:pusher_fast",
 	on_push_item = nil,			-- pusher has no inventory
 	on_unpull_item = nil,		-- pusher has no inventory
 	is_pusher = true,           -- is a pulling/pushing node
-	valid_sides = {R=true, L=true, B=false, F=false, D=false, U=false},
+	valid_sides = {"R","L"},
 	
 	on_recv_message = function(pos, topic, payload)
 		local resp = State:on_receive_message(pos, topic, payload)

--- a/tubelib_addons1/quarry.lua
+++ b/tubelib_addons1/quarry.lua
@@ -448,6 +448,7 @@ minetest.register_craft({
 
 tubelib.register_node("tubelib_addons1:quarry", 
 	{"tubelib_addons1:quarry_active", "tubelib_addons1:quarry_defect"}, {
+	valid_sides = {L=false},
 	on_pull_item = function(pos, side)
 		return tubelib.get_item(M(pos), "main")
 	end,

--- a/tubelib_addons1/quarry.lua
+++ b/tubelib_addons1/quarry.lua
@@ -448,7 +448,7 @@ minetest.register_craft({
 
 tubelib.register_node("tubelib_addons1:quarry", 
 	{"tubelib_addons1:quarry_active", "tubelib_addons1:quarry_defect"}, {
-	valid_sides = {L=false},
+	invalid_sides = {"L"},
 	on_pull_item = function(pos, side)
 		return tubelib.get_item(M(pos), "main")
 	end,

--- a/tubelib_addons3/funnel.lua
+++ b/tubelib_addons3/funnel.lua
@@ -141,6 +141,7 @@ minetest.register_craft({
 
 
 tubelib.register_node("tubelib_addons3:funnel", {}, {
+	valid_sides = {U=false},
 	on_pull_stack = function(pos, side)
 		local meta = minetest.get_meta(pos)
 		return tubelib.get_stack(meta, "main")

--- a/tubelib_addons3/funnel.lua
+++ b/tubelib_addons3/funnel.lua
@@ -141,7 +141,7 @@ minetest.register_craft({
 
 
 tubelib.register_node("tubelib_addons3:funnel", {}, {
-	valid_sides = {U=false},
+	invalid_sides = {"U"},
 	on_pull_stack = function(pos, side)
 		local meta = minetest.get_meta(pos)
 		return tubelib.get_stack(meta, "main")

--- a/tubelib_addons3/pusher.lua
+++ b/tubelib_addons3/pusher.lua
@@ -219,7 +219,7 @@ minetest.register_craft({
 tubelib.register_node("tubelib_addons3:pusher", 
 	{"tubelib_addons3:pusher_active", "tubelib_addons3:pusher_defect"}, {
 	is_pusher = true,           -- is a pulling/pushing node
-	valid_sides = {R=true, L=true, B=false, F=false, D=false, U=false},
+	valid_sides = {"R","L"},
 
 	on_recv_message = function(pos, topic, payload)
 		local resp = State:on_receive_message(pos, topic, payload)

--- a/tubelib_addons3/pusher.lua
+++ b/tubelib_addons3/pusher.lua
@@ -219,6 +219,7 @@ minetest.register_craft({
 tubelib.register_node("tubelib_addons3:pusher", 
 	{"tubelib_addons3:pusher_active", "tubelib_addons3:pusher_defect"}, {
 	is_pusher = true,           -- is a pulling/pushing node
+	valid_sides = {R=true, L=true, B=false, F=false, D=false, U=false},
 
 	on_recv_message = function(pos, topic, payload)
 		local resp = State:on_receive_message(pos, topic, payload)


### PR DESCRIPTION
Fixes #75 

Pushers only connect from the left & right
Detectors only connect from the left & right, still need condition to stop pushing in from the right
Funnels refuse to connect from the top
Liquid samplers & quarries refuse to connect from the front (left)
Black hole push filter replaced with valid_sides logic