### PR TITLE
Use item stack count to avoid overfilling

### DIFF
--- a/techpack_warehouse/common.lua
+++ b/techpack_warehouse/common.lua
@@ -209,7 +209,8 @@ function techpack_warehouse.allow_metadata_inventory_put(self, pos, listname, in
 	local main_stack = inv:get_stack("main", index)
 	local item_name = inv:get_stack("filter", index):get_name()
 	if listname == "input" and item_name == stack:get_name() then
-		return math.min(stack:get_count(), self.inv_size - main_stack:get_count())
+		local input_stack = inv:get_stack("input", index)
+		return math.min(stack:get_count(), self.inv_size - main_stack:get_count() - input_stack:get_count())
 	elseif listname == "filter" and item_name == main_stack:get_name() then
 		return 1
 	elseif listname == "shift" then


### PR DESCRIPTION
Fixes #77 

It turns out you can increase the number of items in the input stack by shift-clicking items in multiple times before it gets sent to the main inventory.
This adds a little math to make sure that possibility is taken into account.