### PR TITLE
Make sure pushers do not keep running if they have been stopped; Allow tubelib machines to have a 'first_cycle' time for first run

### DIFF
--- a/tubelib/pusher.lua
+++ b/tubelib/pusher.lua
@@ -39,6 +39,7 @@ local M = minetest.get_meta
 local STANDBY_TICKS = 5
 local COUNTDOWN_TICKS = 5
 local CYCLE_TIME = 2
+local FIRST_CYCLE = 0.5
 
 local State = tubelib.NodeStates:new({
 	node_name_passive = "tubelib:pusher",
@@ -46,6 +47,7 @@ local State = tubelib.NodeStates:new({
 	node_name_defect = "tubelib:pusher_defect",
 	infotext_name = S("Tubelib Pusher"),
 	cycle_time = CYCLE_TIME,
+	first_cycle_time = FIRST_CYCLE,
 	standby_ticks = STANDBY_TICKS,
 	has_item_meter = true,
 	aging_factor = 10,
@@ -61,7 +63,9 @@ local function pushing(pos, meta)
 			State:blocked(pos, meta)
 			return
 		end
-		State:keep_running(pos, meta, COUNTDOWN_TICKS)
+		if State.get_state(pos, meta) ~= tubelib.STOPPED then
+			State:keep_running(pos, meta, COUNTDOWN_TICKS)
+		end
 		return
 	end
 	State:idle(pos, meta)

--- a/tubelib_addons1/pusher_fast.lua
+++ b/tubelib_addons1/pusher_fast.lua
@@ -39,6 +39,7 @@ local M = minetest.get_meta
 local STANDBY_TICKS = 5
 local COUNTDOWN_TICKS = 5
 local CYCLE_TIME = 1
+local FIRST_CYCLE = 0.5
 
 local State = tubelib.NodeStates:new({
 	node_name_passive = "tubelib_addons1:pusher_fast",
@@ -46,6 +47,7 @@ local State = tubelib.NodeStates:new({
 	node_name_defect = "tubelib_addons1:pusher_fast_defect",
 	infotext_name = S("Fast Pusher"),
 	cycle_time = CYCLE_TIME,
+	first_cycle_time = FIRST_CYCLE,
 	standby_ticks = STANDBY_TICKS,
 	has_item_meter = true,
 	aging_factor = 30,
@@ -61,7 +63,9 @@ local function pushing(pos, meta)
 			State:blocked(pos, meta)
 			return
 		end
-		State:keep_running(pos, meta, COUNTDOWN_TICKS)
+		if State.get_state(pos, meta) ~= tubelib.STOPPED then
+			State:keep_running(pos, meta, COUNTDOWN_TICKS)
+		end
 		return
 	end
 	State:idle(pos, meta)

--- a/tubelib_addons3/pusher.lua
+++ b/tubelib_addons3/pusher.lua
@@ -24,6 +24,7 @@ local M = minetest.get_meta
 local STANDBY_TICKS = 5
 local COUNTDOWN_TICKS = 5
 local CYCLE_TIME = 2
+local FIRST_CYCLE = 0.5
 
 local State = tubelib.NodeStates:new({
 	node_name_passive = "tubelib_addons3:pusher",
@@ -31,6 +32,7 @@ local State = tubelib.NodeStates:new({
 	node_name_defect = "tubelib_addons3:pusher_defect",
 	infotext_name = S("HighPerf Pusher"),
 	cycle_time = CYCLE_TIME,
+	first_cycle_time = FIRST_CYCLE,
 	standby_ticks = STANDBY_TICKS,
 	has_item_meter = true,
 	aging_factor = 50,
@@ -46,7 +48,9 @@ local function pushing(pos, meta)
 			State:blocked(pos, meta)
 			return
 		end
-		State:keep_running(pos, meta, COUNTDOWN_TICKS, 1)
+		if State.get_state(pos, meta) ~= tubelib.STOPPED then
+			State:keep_running(pos, meta, COUNTDOWN_TICKS, 1)
+		end
 		return
 	end
 	State:idle(pos, meta)


### PR DESCRIPTION
Fixes #82 by fixing bugs instead of introducing a new node

- Do not perform the "keep running" functionality if a pusher is in the stopped state, done for all pushers just in case
- Allow tubelib machines to set 'first_cycle_time' that will determine how long it takes for the first cycle to be run, after that it will be run at the normal cycle_time
- Provide a 'first_cycle_time' of 0.5 for all pushers