### PR TITLE
Fix no footstep sound when colorlamp is on

### DIFF
--- a/tubelib_addons2/colorlamp.lua
+++ b/tubelib_addons2/colorlamp.lua
@@ -124,6 +124,7 @@ for idx,color in ipairs(tColors) do
 
 		paramtype = 'light',
 		light_source = minetest.LIGHT_MAX,	
+		sounds = default.node_sound_stone_defaults(),
 		groups = {choppy=2, cracky=1, not_in_creative_inventory=1},
 		is_ground_content = false,
 		drop = "tubelib_addons2:lamp"

--- a/tubelib_addons2/colorlamp_ud.lua
+++ b/tubelib_addons2/colorlamp_ud.lua
@@ -71,6 +71,7 @@ minetest.register_node("tubelib_addons2:lamp_on", {
 	paramtype = "light",
 	paramtype2 = "color",
 	palette = "unifieddyes_palette_extended.png",
+	sounds = default.node_sound_stone_defaults(),
 	groups = {choppy=2, cracky=1, not_in_creative_inventory=1, ud_param2_colorable = 1},
 	
 	on_construct = unifieddyes.on_construct,


### PR DESCRIPTION
Add missing sounds field for activated color lamp from `tubelib_addons2`.