### PR TITLE
Provide default for all instances of retrieving a distributor filter

### DIFF
--- a/tubelib/distributor.lua
+++ b/tubelib/distributor.lua
@@ -316,7 +316,7 @@ local function on_receive_fields(pos, formname, fields, player)
 		return
 	end
 	local meta = M(pos)
-	local filter = minetest.deserialize(meta:get_string("filter"))
+	local filter = minetest.deserialize(meta:get_string("filter")) or {false,false,false,false}
 	if fields.filter1 ~= nil then
 		filter[1] = fields.filter1 == "true"
 	elseif fields.filter2 ~= nil then
@@ -341,7 +341,7 @@ end
 local function change_filter_settings(pos, slot, val)
 	local slots = {["red"] = 1, ["green"] = 2, ["blue"] = 3, ["yellow"] = 4}
 	local meta = M(pos)
-	local filter = minetest.deserialize(meta:get_string("filter"))
+	local filter = minetest.deserialize(meta:get_string("filter")) or {false,false,false,false}
 	local num = slots[slot] or 1
 	if num >= 1 and num <= 4 then
 		filter[num] = val == "on"

--- a/tubelib_addons3/distributor.lua
+++ b/tubelib_addons3/distributor.lua
@@ -285,7 +285,7 @@ local function on_receive_fields(pos, formname, fields, player)
 		return
 	end
 	local meta = M(pos)
-	local filter = minetest.deserialize(meta:get_string("filter"))
+	local filter = minetest.deserialize(meta:get_string("filter")) or {false,false,false,false}
 	if fields.filter1 ~= nil then
 		filter[1] = fields.filter1 == "true"
 	elseif fields.filter2 ~= nil then
@@ -310,7 +310,7 @@ end
 local function change_filter_settings(pos, slot, val)
 	local slots = {["red"] = 1, ["green"] = 2, ["blue"] = 3, ["yellow"] = 4}
 	local meta = M(pos)
-	local filter = minetest.deserialize(meta:get_string("filter"))
+	local filter = minetest.deserialize(meta:get_string("filter")) or {false,false,false,false}
 	local num = slots[slot] or 1
 	if num >= 1 and num <= 4 then
 		filter[num] = val == "on"


### PR DESCRIPTION
This was seen on the highperf distributor, decided to make sure it's fixed for the default distributor too

Fixes https://github.com/joe7575/techpack/issues/93