### PR TITLE
Fixed bug where sieve_defect didn't check for protection

### DIFF
--- a/gravelsieve/init.lua
+++ b/gravelsieve/init.lua
@@ -627,6 +627,10 @@ if minetest.global_exists("tubelib") then
 			end
 		end,
 
+		allow_metadata_inventory_put = allow_metadata_inventory_put,
+		allow_metadata_inventory_move = allow_metadata_inventory_move,
+		allow_metadata_inventory_take = allow_metadata_inventory_take,
+
 		paramtype = "light",
 		sounds = default.node_sound_wood_defaults(),
 		paramtype2 = "facedir",


### PR DESCRIPTION
Gravelsieve checks for protection but if it is defect, protection is not honored. This change simply grabs the same lines from gravelsieve and adds them to sieve_defect