### PR TITLE
Quarry will no longer allow to dig if it has fuel

### DIFF
--- a/tubelib_addons1/quarry.lua
+++ b/tubelib_addons1/quarry.lua
@@ -417,7 +417,7 @@ minetest.register_node("tubelib_addons1:quarry_defect", {
 			return false
 		end
 		local inv = M(pos):get_inventory()
-		return inv:is_empty("main")
+		return inv:is_empty("main") and inv:is_empty("fuel")
 	end,
 
 	after_dig_node = function(pos, oldnode, oldmetadata, digger)


### PR DESCRIPTION
Currently if you dig quarry while it has fuel, the fuel will be lost