### PR TITLE
Add an on-blast callback to all machines that performs a no-op to disable TNT destruction

### DIFF
--- a/gravelsieve/init.lua
+++ b/gravelsieve/init.lua
@@ -571,6 +571,7 @@ for idx = 0,4 do
 		is_ground_content = false,
 		groups = {choppy=2, cracky=1, not_in_creative_inventory=not_in_creative_inventory, tubedevice = 1, tubedevice_receiver = 1},
 		drop = node_name.."3",
+		on_blast = function() end,
 	})
 end
 end
@@ -637,6 +638,7 @@ if minetest.global_exists("tubelib") then
 		sunlight_propagates = true,
 		is_ground_content = false,
 		groups = {choppy=2, cracky=1, not_in_creative_inventory=1},
+		on_blast = function() end,
 	})
 
 	tubelib.register_node("gravelsieve:auto_sieve3",
@@ -758,5 +760,3 @@ if minetest.get_modpath("moreblocks") then
 		sounds = default.node_sound_stone_defaults(),
 	})
 end
-
-

--- a/sl_controller/battery.lua
+++ b/sl_controller/battery.lua
@@ -9,13 +9,13 @@
 	See LICENSE.txt for more information
 
 	battery.lua:
-	
+
 	REPLACED BY SMARTLINE BATTERY !!!
 
 ]]--
 
 local function calc_percent(content)
-	local val = (sl_controller.battery_capacity - 
+	local val = (sl_controller.battery_capacity -
 			math.min(content or 0, sl_controller.battery_capacity))
 	return 100 - math.floor((val * 100.0 / sl_controller.battery_capacity))
 end
@@ -55,7 +55,7 @@ local function register_battery(ext, percent, nici)
 				{ -6/32, -6/32, 14/32,  6/32,  6/32, 16/32},
 			},
 		},
-		
+
 		after_place_node = function(pos, placer)
 			local meta = minetest.get_meta(pos)
 			meta:set_int("content", sl_controller.battery_capacity * percent)
@@ -65,10 +65,10 @@ local function register_battery(ext, percent, nici)
 			on_timer(pos, 1)
 			minetest.get_node_timer(pos):start(30)
 		end,
-		
+
 		on_timer = on_timer,
-		
-		
+
+
 		after_dig_node = function(pos, oldnode, oldmetadata, digger)
 			local percent = calc_percent(tonumber(oldmetadata.fields.content))
 			local stack
@@ -94,6 +94,7 @@ local function register_battery(ext, percent, nici)
 		drop = "",
 		is_ground_content = false,
 		sounds = default.node_sound_stone_defaults(),
+		on_blast = function() end,
 	})
 end
 
@@ -121,12 +122,12 @@ minetest.register_node("sl_controller:battery_empty", {
 			{ -6/32, -6/32, 14/32,  6/32,  6/32, 16/32},
 		},
 	},
-	
+
 	after_place_node = function(pos, placer)
 		local meta = minetest.get_meta(pos)
 		meta:set_int("content", 0)
 	end,
-	
+
 	paramtype = "light",
 	sunlight_propagates = true,
 	paramtype2 = "facedir",
@@ -134,6 +135,7 @@ minetest.register_node("sl_controller:battery_empty", {
 	drop = "",
 	is_ground_content = false,
 	sounds = default.node_sound_stone_defaults(),
+	on_blast = function() end,
 })
 
 

--- a/sl_controller/server.lua
+++ b/sl_controller/server.lua
@@ -14,7 +14,7 @@
 
 local SERVER_CAPA = 5000
 local DEFAULT_MEM = {
-	size=0, 
+	size=0,
 	data={
 		version = 1,
 		info = "SaferLua key/value Server",
@@ -71,7 +71,7 @@ minetest.register_node("sl_controller:server", {
 			{ -3/16, -8/16, -7/16, 3/16, 6/16, 7/16},
 		},
 	},
-	
+
 	after_place_node = function(pos, placer)
 		local meta = minetest.get_meta(pos)
 		local number = tubelib.add_node(pos, "sl_controller:server")
@@ -82,7 +82,7 @@ minetest.register_node("sl_controller:server", {
 		on_time(pos, 0)
 		minetest.get_node_timer(pos):start(20)
 	end,
-	
+
 	on_receive_fields = function(pos, formname, fields, player)
 		local meta = minetest.get_meta(pos)
 		local owner = meta:get_string("owner")
@@ -94,7 +94,7 @@ minetest.register_node("sl_controller:server", {
 			end
 		end
 	end,
-	
+
 	on_dig = function(pos, node, puncher, pointed_thing)
 		if minetest.is_protected(pos, puncher:get_player_name()) then
 			return
@@ -105,15 +105,16 @@ minetest.register_node("sl_controller:server", {
 		minetest.node_dig(pos, node, puncher, pointed_thing)
 		tubelib.remove_node(pos)
 	end,
-		
+
 	on_timer = on_time,
-	
+
 	paramtype = "light",
 	sunlight_propagates = true,
 	paramtype2 = "facedir",
 	groups = {choppy=1, cracky=1, crumbly=1},
 	is_ground_content = false,
 	sounds = default.node_sound_stone_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_craft({
@@ -167,7 +168,7 @@ local function write_value(mem, key, item)
 		mem.size = mem.size + calc_size(item)
 		mem.data[key] = item
 	end
-end	
+end
 
 local function read_value(mem, key)
 	local item = mem.data[key]
@@ -175,7 +176,7 @@ local function read_value(mem, key)
 		item = safer_lua.table_to_datastruct(item)
 	end
 	return item
-end	
+end
 
 tubelib.register_node("sl_controller:server", {}, {
 	on_recv_message = function(pos, topic, payload)
@@ -184,11 +185,11 @@ tubelib.register_node("sl_controller:server", {}, {
 	on_node_load = function(pos)
 		minetest.get_node_timer(pos):start(20)
 	end,
-})		
+})
 
 
 sl_controller.register_function("server_read", {
-	cmnd = function(self, num, key) 
+	cmnd = function(self, num, key)
 		if type(key) == "string" then
 			local mem = get_memory(num, self.meta.owner)
 			if mem then
@@ -221,5 +222,3 @@ sl_controller.register_action("server_write", {
 		" number, string, boolean, nil or data structure.\n"..
 		' example: $server_write("0123", "state", state)'
 })
-
-

--- a/sl_controller/terminal.lua
+++ b/sl_controller/terminal.lua
@@ -9,7 +9,7 @@
 	See LICENSE.txt for more information
 
 	terminal.lua:
-	
+
 ]]--
 
 local HELP = [[#### SmartLine Controller Terminal ####
@@ -21,7 +21,7 @@ Controller to the Terminal.
 Commands can have up to 80 characters.
 Local commands:
 - clear    = clear screen
-- help     = this message 
+- help     = this message
 - pub      = switch to public use
 - priv      = switch to private use
 Global commands:
@@ -66,7 +66,7 @@ local function command(pos, cmnd, player)
 	local owner = meta:get_string("owner") or ""
 	if cmnd then
 		cmnd = cmnd:sub(1,80)
-		
+
 		if cmnd == "clear" then
 			meta:set_string("output", "")
 			meta:set_string("formspec", formspec2(meta))
@@ -104,7 +104,7 @@ local function command(pos, cmnd, player)
 			tubelib.send_message(number, owner, nil, "term", cmnd)
 		end
 	end
-end	
+end
 
 local function register_terminal(num, tiles, node_box, selection_box)
 	minetest.register_node("sl_controller:terminal"..num, {
@@ -113,7 +113,7 @@ local function register_terminal(num, tiles, node_box, selection_box)
 		drawtype = "nodebox",
 		node_box = node_box,
 		selection_box = selection_box,
-		
+
 		after_place_node = function(pos, placer)
 			local number = tubelib.add_node(pos, minetest.get_node(pos).name)
 			local meta = minetest.get_meta(pos)
@@ -136,17 +136,18 @@ local function register_terminal(num, tiles, node_box, selection_box)
 				command(pos, fields.cmnd, player:get_player_name())
 			end
 		end,
-		
+
 		after_dig_node = function(pos)
 			tubelib.remove_node(pos)
 		end,
-		
+
 		paramtype = "light",
 		sunlight_propagates = true,
 		paramtype2 = "facedir",
 		groups = {choppy=2, cracky=2, crumbly=2},
 		is_ground_content = false,
 		sounds = default.node_sound_metal_defaults(),
+		on_blast = function() end,
 	})
 end
 
@@ -235,7 +236,7 @@ tubelib.register_node("sl_controller:terminal2", {}, {
 			return true
 		end
 	end,
-})		
+})
 
 sl_controller.register_function("get_term", {
 	cmnd = function(self)
@@ -279,4 +280,3 @@ sl_controller.register_action("send_msg", {
 		' Send a message to the controller with number "num".\n'..
 		' example: $send_msg("0123", "test")'
 })
-

--- a/smartline/button.lua
+++ b/smartline/button.lua
@@ -85,13 +85,13 @@ minetest.register_node("smartline:button", {
 			{ -6/32, -6/32, 14/32,  6/32,  6/32, 16/32},
 		},
 	},
-	
+
 	after_place_node = function(pos, placer)
 		local meta = minetest.get_meta(pos)
 		local own_num = tubelib.add_node(pos, "smartline:button")
 		meta:set_string("own_num", own_num)
 		meta:set_string("formspec", "size[5,6]"..
-		"dropdown[0.2,0;3;type;"..S("switch,button 2s,button 4s,button 8s,button 16s")..";1]".. 
+		"dropdown[0.2,0;3;type;"..S("switch,button 2s,button 4s,button 8s,button 16s")..";1]"..
 		"field[0.5,2;3,1;numbers;"..S("Insert destination block number(s)")..";]" ..
 		"checkbox[1,3;public;public;false]"..
 		"button_exit[1,4;2,1;exit;"..S("Save").."]")
@@ -133,7 +133,7 @@ minetest.register_node("smartline:button", {
 			meta:set_string("formspec", nil)
 		end
 	end,
-	
+
 	on_rightclick = function(pos, node, clicker)
 		local meta = minetest.get_meta(pos)
 		if meta:get_string("numbers") ~= "" and meta:get_string("numbers") ~= nil then
@@ -152,6 +152,7 @@ minetest.register_node("smartline:button", {
 	groups = {cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 
@@ -174,7 +175,7 @@ minetest.register_node("smartline:button_active", {
 			{ -6/32, -6/32, 14/32,  6/32,  6/32, 16/32},
 		},
 	},
-	
+
 	on_rightclick = function(pos, node, clicker)
 		local meta = minetest.get_meta(pos)
 		meta:set_string("clicker_name", clicker:get_player_name())
@@ -196,6 +197,7 @@ minetest.register_node("smartline:button_active", {
 	drop = "smartline:button",
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 tubelib.register_node("smartline:button", {"smartline:button_active"}, {tubelib_node = true})

--- a/smartline/collector.lua
+++ b/smartline/collector.lua
@@ -9,7 +9,7 @@
 	See LICENSE.txt for more information
 
 	collector.lua:
-	
+
 	Collects states from other nodes, acting as a state concentrator.
 
 ]]--
@@ -22,13 +22,13 @@ local CYCLE_TIME = 1
 local tStates = {stopped = 0, running = 0, standby = 1, blocked = 2, fault = 3, defect = 4}
 local tDropdownPos = {["1 standby"] = 1, ["2 blocked"] = 2 , ["3 fault"] = 3, ["4 defect"] = 4}
 local lStates = {[0] = "stopped", "standby", "blocked", "fault", "defect"}
-	
+
 local function formspec(meta)
 	local poll_numbers = meta:get_string("poll_numbers")
 	local event_number = meta:get_string("event_number")
 	local dropdown_pos = meta:get_int("dropdown_pos")
 	if dropdown_pos == 0 then dropdown_pos = 1 end
-	
+
 	return "size[9,6]"..
 		default.gui_bg..
 		default.gui_bg_img..
@@ -38,7 +38,7 @@ local function formspec(meta)
 		"label[1.3,2.8;"..S("Send an event if state is equal or larget than:").."]"..
 		"dropdown[1.2,3.4;7,4;severity;1 standby,2 blocked,3 fault,4 defect;"..dropdown_pos.."]"..
 		"button_exit[3,5;2,1;exit;"..S("Save").."]"
-end	
+end
 
 
 local function send_event(meta)
@@ -74,7 +74,7 @@ local function on_timer(pos,elapsed)
 		local meta = minetest.get_meta(pos)
 		local poll_numbers = meta:get_string("poll_numbers")
 		local idx = meta:get_int("index") + 1
-		
+
 		if poll_numbers == "" then
 			local own_number = meta:get_string("own_number")
 			meta:set_string("infotext", S("SmartLine State Collector").." "..own_number..": stopped")
@@ -82,15 +82,15 @@ local function on_timer(pos,elapsed)
 			meta:set_int("stored_state", 0)
 			return false
 		end
-		
+
 		if idx > meta:get_int("num_numbers") then
 			idx = 1
 			send_event(meta)
 		end
 		meta:set_int("index", idx)
-		
+
 		request_state(meta, poll_numbers, idx)
-		
+
 		return true
 	end
 	return false
@@ -161,11 +161,11 @@ minetest.register_node("smartline:collector", {
 			end
 			meta:set_string("formspec", formspec(meta))
 		end
-		
+
 	end,
-	
+
 	on_timer = on_timer,
-	
+
 	after_dig_node = function(pos)
 		tubelib.remove_node(pos)
 	end,
@@ -176,6 +176,7 @@ minetest.register_node("smartline:collector", {
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_stone_defaults(),
+	on_blast = function() end,
 })
 
 
@@ -210,4 +211,4 @@ tubelib.register_node("smartline:collector", {}, {
 	on_node_load = function(pos)
 		minetest.get_node_timer(pos):start(CYCLE_TIME)
 	end,
-})		
+})

--- a/smartline/controller.lua
+++ b/smartline/controller.lua
@@ -17,7 +17,7 @@
 local NUM_RULES = 10
 
 local mail_exists = minetest.get_modpath("mail") and mail ~= nil
- 
+
 local sHELP = [[SmartLine Controller Help
 
 Control other nodes by means of rules, according to:
@@ -28,27 +28,27 @@ Examples for conditions are:
  - the Player Detector detects a player
  - a button is pressed
  - a node state is fault, blocked, standby,...
- - a timer is expired 
- 
+ - a timer is expired
+
 Actions are:
  - switch on/off tubelib nodes, like lamps, door blocks, machines
  - send mail/chat messages to the owner
  - output a text message to the display
- - set timer variables 
+ - set timer variables
  - set/reset flag variables
- 
-Variables and timers: 
- - 8 flags (set/reset) can be used to store conditions 
+
+Variables and timers:
+ - 8 flags (set/reset) can be used to store conditions
     for later use.
  - Action flags (one flag for each rule, set when action is executed)
     The flag can be used as condition for subsequent rules.
  - 8 timers (resolution in seconds) can be use
-   for delayed actions. 
+   for delayed actions.
 
-The controller executes all rules once per second. 
+The controller executes all rules once per second.
 Independent how long the input condition stays 'true',
 the corresponding action will be triggered only once.
-The condition has to become false and then true again, to 
+The condition has to become false and then true again, to
 re-trigger/execute the action again.
 
 The 'label' has no function. It is only used
@@ -66,12 +66,12 @@ It has a 'update' button to update the view.
 
 ]]
 
-local sOUTPUT = "Press 'help' for edit commands" 
- 
+local sOUTPUT = "Press 'help' for edit commands"
+
 --
 -- Helper functions
 --
-local function create_kv_list(elem) 
+local function create_kv_list(elem)
 	local a = {}
 	for i,v in ipairs(elem) do
 		a[v] = i
@@ -181,16 +181,16 @@ local function get_active_subm_definition(postfix, type, fs_data)
 	return idx, fs_definition
 end
 
--- Extract runtime relevant data from the given submenu 
+-- Extract runtime relevant data from the given submenu
 -- postfix: row/culum info like "11" or "a2"
 -- fs_definition: submenu formspec definition
 -- fs_data: formspec data
 local function get_subm_data(postfix, fs_definition, fs_data)
 	local data = {}
 	for idx,elem in ipairs(fs_definition.formspec) do
-		if elem.type == "field" then	
+		if elem.type == "field" then
 			data[elem.name] = fs_data["subm"..postfix.."_"..elem.name] or "?"
-		elseif elem.type == "textlist" then	
+		elseif elem.type == "textlist" then
 			local num = tonumber(fs_data["subm"..postfix.."_"..elem.name]) or 1
 			num = math.min(num, elem.num_choices)
 			data[elem.name] = num
@@ -209,11 +209,11 @@ end
 local function field2fs_data(fs_definition, fields, fs_data)
 	for idx,elem in ipairs(fs_definition.formspec) do
 		local key = "subm"..fields._postfix_.."_"..elem.name
-		if elem.type == "field" then	
+		if elem.type == "field" then
 			if fields[elem.name] then
 				fs_data[key] = fields[elem.name]
 			end
-		elseif elem.type == "textlist" then	
+		elseif elem.type == "textlist" then
 			local evt = minetest.explode_textlist_event(fields[elem.name])
 			if evt.type == "CHG" then
 				fs_data[key] = evt.index
@@ -278,7 +278,7 @@ local function formspec_cond(_postfix_, fs_data)
 		default.gui_slots..
 		"field[0,0;0,0;_type_;;cond]"..
 		"field[0,0;0,0;_postfix_;;".._postfix_.."]"}
-	
+
 	local sConditions = table.concat(aCondTitles, ",")
 	local cond_idx, fs_definition = get_active_subm_definition(_postfix_, "cond", fs_data)
 	tbl[#tbl+1] = "label[0,0.1;Condition type:]"
@@ -291,7 +291,7 @@ end
 
 -- evaluate the row condition
 local function eval_formspec_cond(meta, fs_data, fields, readonly)
-	if readonly then return fs_data end 
+	if readonly then return fs_data end
 	-- determine condition type
 	local cond = minetest.explode_textlist_event(fields.cond)
 	if cond.type == "CHG" then
@@ -303,14 +303,14 @@ local function eval_formspec_cond(meta, fs_data, fields, readonly)
 	local data = get_subm_data(fields._postfix_, fs_definition, fs_data)
 	-- update button for main menu
 	fs_data["cond"..fields._postfix_] = fs_definition.button_label(data)
-	
+
 	if fields._exit_ == nil then
 		-- update formspec if exit is not pressed
 		meta:set_string("formspec", formspec_cond(fields._postfix_, fs_data))
 	end
 	return fs_data
 end
-	
+
 
 --
 -- Action formspec
@@ -322,7 +322,7 @@ local function formspec_actn(_postfix_, fs_data)
 		default.gui_slots..
 		"field[0,0;0,0;_type_;;actn]"..
 		"field[0,0;0,0;_postfix_;;".._postfix_.."]"}
-	
+
 	local sActions = table.concat(aActnTitles, ",")
 	local actn_idx, fs_definition = get_active_subm_definition(_postfix_, "actn", fs_data)
 	tbl[#tbl+1] = "label[0,0.1;Action type:]"
@@ -335,7 +335,7 @@ end
 
 -- evaluate the row action
 local function eval_formspec_actn(meta, fs_data, fields, readonly)
-	if readonly then return fs_data end 
+	if readonly then return fs_data end
 	-- determine action type
 	local actn = minetest.explode_textlist_event(fields.actn)
 	if actn.type == "CHG" then
@@ -347,7 +347,7 @@ local function eval_formspec_actn(meta, fs_data, fields, readonly)
 	local data = get_subm_data(fields._postfix_, fs_definition, fs_data)
 	-- update button for main menu
 	fs_data["actn"..fields._postfix_] = fs_definition.button_label(data)
-	
+
 	if fields._exit_ == nil then
 		-- update formspec if exit is not pressed
 		meta:set_string("formspec", formspec_actn(fields._postfix_, fs_data))
@@ -377,7 +377,7 @@ end
 
 -- evaluate the row label
 local function eval_formspec_label(meta, fs_data, fields, readonly)
-	if readonly then return fs_data end 
+	if readonly then return fs_data end
 	fs_data["subml"..fields._postfix_.."_label"] = fields.label
 	if fields._exit_ == nil then
 		meta:set_string("formspec", formspec_label(fields._postfix_, fs_data))
@@ -406,7 +406,7 @@ end
 
 -- evaluate the row operand
 local function eval_formspec_oprnd(meta, fs_data, fields, readonly)
-	if readonly then return fs_data end 
+	if readonly then return fs_data end
 	local oprnd = minetest.explode_textlist_event(fields.oprnd)
 	if oprnd.type == "CHG" then
 		fs_data["submo"..fields._postfix_.."_oprnd"] = oprnd.index
@@ -426,7 +426,7 @@ local function formspec_main(state, fs_data, output)
 		default.gui_slots..
 		"field[0,0;0,0;_type_;;main]"..
 		"label[0.8,0;label:]label[3.8,0;IF  cond 1:]label[7,0;and/or]label[8.3,0;cond 2:]label[11.7,0;THEN  action:]"}
-		
+
 	for idx = 1,NUM_RULES do
 		local ypos = idx * 0.75 - 0.4
 		tbl[#tbl+1] = "label[0,"..(0.2+ypos)..";"..idx.."]"
@@ -452,7 +452,7 @@ local function eval_formspec_main(meta, fs_data, fields, readonly)
 		if not readonly then
 			fs_data["oprnd"..idx] = fields["oprnd"..idx] or fs_data["oprnd"..idx]
 		end
-		
+
 		-- eval submenu button events
 		if fields["label"..idx] then
 			meta:set_string("formspec", formspec_label(idx, fs_data))
@@ -465,7 +465,7 @@ local function eval_formspec_main(meta, fs_data, fields, readonly)
 		elseif fields["actna"..idx] then
 			meta:set_string("formspec", formspec_actn("a"..idx, fs_data))
 		end
-	end	
+	end
 	return fs_data
 end
 
@@ -489,7 +489,7 @@ local function background(xpos, ypos, val)
 	else
 		return "box["..(xpos-0.1)..",".. ypos..";3.3,0.4;#202020]"
 	end
-end	
+end
 
 local function formspec_state(meta, fs_data)
 	local number = meta:get_string("number")
@@ -500,12 +500,12 @@ local function formspec_state(meta, fs_data)
 		default.gui_slots..
 		"field[0,0;0,0;_type_;;state]"..
 		"label[0.8,0;label:]label[3.8,0;IF  cond 1:]label[7,0;and/or]label[8.3,0;cond 2:]label[11.7,0;THEN  action:]"}
-	
+
 	if state == tubelib.RUNNING and number then
-		local environ = tubelib.get_data(number, "environ") 
+		local environ = tubelib.get_data(number, "environ")
 		local act_gate = tubelib.get_data(number, "act_gate")
 		local conds = tubelib.get_data(number, "conds")
-		
+
 		if environ and act_gate and conds then
 			for idx = 1,NUM_RULES do
 				local ypos = idx * 0.6 + 0.2
@@ -530,13 +530,13 @@ local function formspec_state(meta, fs_data)
 					act_gate[idx] = false
 				end
 			end
-			
+
 			tbl[#tbl+1] = "label[10,7; Seconds: "..(meta:get_int("runtime") or 1).."]"
 
 			tbl[#tbl+1] = "label[0,7;"..output("Inputs", "i(", ")", environ.inputs).."]"
 			tbl[#tbl+1] = "label[0,7.6;"..output("Timers", "t", "", environ.timers).."]"
 			tbl[#tbl+1] = "label[0,8.2;"..output("Flags", "f", "", environ.flags).."]"
-			
+
 			tbl[#tbl+1] = "label[0,8.8;Hint:]"
 			tbl[#tbl+1] = "box[1.3,8.8;6,0.4;#008000]"
 			tbl[#tbl+1] = "label[1.4,8.8;condition true / action executed]"
@@ -544,7 +544,7 @@ local function formspec_state(meta, fs_data)
 			tbl[#tbl+1] = "label[8,8.8;condition false / action out-of-date]"
 		end
 	end
-	
+
 	tbl[#tbl+1] = "button[13.3,6.9;1.7,1;update;update]"
 	tbl[#tbl+1] = "button[13.3,7.8;1.7,1;close;close]"
 	return table.concat(tbl)
@@ -610,8 +610,8 @@ end
 local function start_controller(pos, number, fs_data)
 	-- delete old data
 	tubelib.set_data(number, "environ",  {
-		timers = {}, 
-		flags = {}, 
+		timers = {},
+		flags = {},
 		inputs = {}
 	})
 	tubelib.set_data(number, "conds",    {})
@@ -628,7 +628,7 @@ local function formspec2runtime_rule(number, owner, fs_data)
 	local num2inp = {}
 	for idx = 1,NUM_RULES do
 		-- valid rule?
-		if fs_data["subm1"..idx.."_cond"] and fs_data["subm2"..idx.."_cond"] 
+		if fs_data["subm1"..idx.."_cond"] and fs_data["subm2"..idx.."_cond"]
 		and fs_data["subma"..idx.."_actn"] then
 			-- add to list of runtine rules
 			local rule = {
@@ -640,7 +640,7 @@ local function formspec2runtime_rule(number, owner, fs_data)
 			rule.actn.owner = owner
 			table.insert(rt_rules, rule)
 		end
-	end 
+	end
 	tubelib.set_data(number, "rt_rules", rt_rules)
 end
 
@@ -697,18 +697,18 @@ local function edit_command(fs_data, text)
 	if cmnd and pos1 and pos2 then
 		pos1 = math.max(1, math.min(pos1, NUM_RULES))
 		pos2 = math.max(1, math.min(pos2, NUM_RULES))
-		
-		if cmnd == "x" then 
-			exchange_rules(fs_data, pos1, pos2) 
+
+		if cmnd == "x" then
+			exchange_rules(fs_data, pos1, pos2)
 			return "rows "..pos1.." and "..pos2.." exchanged"
 		end
 		if cmnd == "c" then
-			copy_rule(fs_data, pos1, pos2) 
+			copy_rule(fs_data, pos1, pos2)
 			return "row "..pos1.." copied to "..pos2
 		end
 	elseif cmnd == "d" and pos1 then
 		pos1 = math.max(1, math.min(pos1, NUM_RULES))
-		
+
 		delete_rule(fs_data, pos1)
 		return "row "..pos1.." deleted"
 	end
@@ -725,10 +725,10 @@ local function on_receive_fields(pos, formname, fields, player)
 	local fs_data = minetest.deserialize(meta:get_string("fs_data")) or {}
 	local output = ""
 	local readonly = player:get_player_name() ~= owner
-	
+
 	-- FIRST: test if command entered?
 	if fields.ok then
-		if not readonly then	
+		if not readonly then
 			output = edit_command(fs_data, fields.cmnd)
 			smartline.stop_controller(pos, fs_data)
 			meta:set_string("formspec", formspec_main(tubelib.STOPPED, fs_data, output))
@@ -816,12 +816,12 @@ minetest.register_node("smartline:controller", {
 			{ -6/32, -6/32, 14/32,  6/32,  6/32, 16/32},
 		},
 	},
-	
+
 	after_place_node = function(pos, placer)
 		local meta = minetest.get_meta(pos)
 		local number = tubelib.add_node(pos, "smartline:controller")
 		local fs_data = {}
-		meta:set_string("fs_data", minetest.serialize(fs_data)) 
+		meta:set_string("fs_data", minetest.serialize(fs_data))
 		meta:set_string("owner", placer:get_player_name())
 		meta:set_string("number", number)
 		meta:set_int("state", tubelib.STOPPED)
@@ -831,24 +831,25 @@ minetest.register_node("smartline:controller", {
 	end,
 
 	on_receive_fields = on_receive_fields,
-	
+
 	on_dig = function(pos, node, puncher, pointed_thing)
 		if minetest.is_protected(pos, puncher:get_player_name()) then
 			return
 		end
-		
+
 		minetest.node_dig(pos, node, puncher, pointed_thing)
 		tubelib.remove_node(pos)
 	end,
-	
+
 	on_timer = check_rules,
-	
+
 	paramtype = "light",
 	sunlight_propagates = true,
 	paramtype2 = "facedir",
 	groups = {choppy=1, cracky=1, crumbly=1, not_in_creative_inventory=1},
 	is_ground_content = false,
 	sounds = default.node_sound_stone_defaults(),
+	on_blast = function() end,
   drop = "smartline:controller2",
 })
 
@@ -864,7 +865,7 @@ minetest.register_craft({
 
 
 local function set_input(meta, payload, val)
-	if payload then 
+	if payload then
 		local number = meta:get_string("number")
 		local environ = tubelib.get_data(number, "environ") or {}
 		if environ.inputs then
@@ -872,7 +873,7 @@ local function set_input(meta, payload, val)
 			tubelib.set_data(number, "environ", environ)
 		end
 	end
-end	
+end
 
 tubelib.register_node("smartline:controller", {}, {
 	on_recv_message = function(pos, topic, payload)
@@ -894,11 +895,11 @@ tubelib.register_node("smartline:controller", {}, {
 			minetest.get_node_timer(pos):start(1)
 		end
 	end,
-})		
+})
 
 -- List of Controller actions and conditions is dependent on loaded mods.
 -- Therefore, the order of actions and conditions has to be re-assembled each time.
--- last order from last run is stored as meta data 
+-- last order from last run is stored as meta data
 local storage = minetest.get_mod_storage()
 
 local function old_to_new(newTypes, oldTypes)
@@ -922,7 +923,7 @@ local function update_node_database(meta)
 
 	meta:set_string("aCondTypes", minetest.serialize(aCondTypes))
 	meta:set_string("aActnTypes", minetest.serialize(aActnTypes))
-	
+
 	return tOld2NewCond, tOld2NewActn
 end
 
@@ -931,14 +932,14 @@ local function maintain_dataset(number)
 	if flags ~= nil then
 		local timers = tubelib.get_data(number, "timers") or {}
 		local inputs = tubelib.get_data(number, "inputs") or {}
-		
+
 		tubelib.set_data(number, "environ", {
-			flags = flags, 
-			timers = timers, 
-			inputs = inputs, 
+			flags = flags,
+			timers = timers,
+			inputs = inputs,
 			vars = {}
 		})
-		
+
 		tubelib.set_data(number, "inputs", nil)
 		tubelib.set_data(number, "timers", nil)
 		tubelib.set_data(number, "flags", nil)
@@ -957,7 +958,7 @@ function smartline.update_fs_data(meta, fs_data)
 			fs_data["subm2"..idx.."_cond"] = tOld2NewCond[fs_data["subm2"..idx.."_cond"]]
 			fs_data["subma"..idx.."_actn"] = tOld2NewActn[fs_data["subma"..idx.."_actn"]]
 		end
-		
+
 	end
 	return fs_data
 end
@@ -969,16 +970,15 @@ minetest.register_lbm({
 	run_at_every_load = true,
 	action = function(pos, node)
 		local meta = minetest.get_meta(pos)
-		
+
 		local fs_data = minetest.deserialize(meta:get_string("fs_data"))
 		fs_data = smartline.update_fs_data(meta, fs_data)
 		meta:set_string("fs_data", minetest.serialize(fs_data))
-		
+
 		local number = meta:get_string("number")
 		local owner = meta:get_string("owner")
 		formspec2runtime_rule(number, owner, fs_data)
-	
+
 		maintain_dataset(number)
 	end
 })
-

--- a/smartline/display.lua
+++ b/smartline/display.lua
@@ -14,11 +14,11 @@
 
 -- Load support for I18n
 local S = smartline.S
-  
-  
+
+
 lcdlib.register_display_entity("smartline:entity")
 
-local function display_update(pos, objref) 
+local function display_update(pos, objref)
 	local meta = minetest.get_meta(pos)
 	local text = meta:get_string("text") or ""
 	text = string.gsub(text, "|", " \n")
@@ -54,7 +54,7 @@ minetest.register_node("smartline:display", {
 	node_box = lcd_box,
 	selection_box = lcd_box,
 	light_source = 6,
-	
+
 	display_entities = {
 		["smartline:entity"] = { depth = 0.42,
 			on_display_update = display_update},
@@ -81,6 +81,7 @@ minetest.register_node("smartline:display", {
 	groups = {cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_glass_defaults(),
+	on_blast = function() end,
 })
 
 
@@ -118,7 +119,7 @@ local function write_row(meta, payload)
 		local str = payload.str or "oops"
 		if row == 0 then
 			meta:set_string("infotext", str)
-			return 
+			return
 		end
 		local rows
 		if meta:get_int("startscreen") == 1 then
@@ -162,5 +163,4 @@ tubelib.register_node("smartline:display", {}, {
 			end
 		end
 	end,
-})		
-
+})

--- a/smartline/icta/battery.lua
+++ b/smartline/icta/battery.lua
@@ -54,7 +54,7 @@ local function register_battery(ext, percent, nici)
 				{ -6/32, -6/32, 14/32,  6/32,  6/32, 16/32},
 			},
 		},
-		
+
 		after_place_node = function(pos, placer)
 			local meta = minetest.get_meta(pos)
 			meta:set_int("content", BATTERY_CAPACITY * percent)
@@ -64,10 +64,10 @@ local function register_battery(ext, percent, nici)
 			on_timer(pos, 1)
 			minetest.get_node_timer(pos):start(30)
 		end,
-		
+
 		on_timer = on_timer,
-		
-		
+
+
 		after_dig_node = function(pos, oldnode, oldmetadata, digger)
 			local percent = calc_percent(tonumber(oldmetadata.fields.content))
 			local stack
@@ -93,6 +93,7 @@ local function register_battery(ext, percent, nici)
 		drop = "",
 		is_ground_content = false,
 		sounds = default.node_sound_stone_defaults(),
+		on_blast = function() end,
 	})
 end
 
@@ -120,12 +121,12 @@ minetest.register_node("smartline:battery_empty", {
 			{ -6/32, -6/32, 14/32,  6/32,  6/32, 16/32},
 		},
 	},
-	
+
 	after_place_node = function(pos, placer)
 		local meta = minetest.get_meta(pos)
 		meta:set_int("content", 0)
 	end,
-	
+
 	paramtype = "light",
 	sunlight_propagates = true,
 	paramtype2 = "facedir",
@@ -133,6 +134,7 @@ minetest.register_node("smartline:battery_empty", {
 	drop = "",
 	is_ground_content = false,
 	sounds = default.node_sound_stone_defaults(),
+	on_blast = function() end,
 })
 
 
@@ -156,8 +158,8 @@ else
 	})
 end
 
-tubelib.register_node("smartline:battery", 
-	{"smartline:battery25", "smartline:battery50", "smartline:battery75"}, 
+tubelib.register_node("smartline:battery",
+	{"smartline:battery25", "smartline:battery50", "smartline:battery75"},
 	{
 		on_node_load = function(pos)
 			minetest.get_node_timer(pos):start(30)

--- a/smartline/icta/controller.lua
+++ b/smartline/icta/controller.lua
@@ -4,7 +4,7 @@
 	===============
 
 	Part of the SmartLine mod
-	
+
 	Copyright (C) 2017-2020 Joachim Stolberg
 
 	AGPL v3
@@ -17,7 +17,7 @@
 --
 -- Helper functions
 --
-local function gen_table(size, val) 
+local function gen_table(size, val)
 	local tbl = {}
 	for idx = 1,size do
 		if type(val) == "table" then
@@ -39,14 +39,14 @@ local function integer(s, min, max)
 	return min
 end
 
-local sOUTPUT = "Edit commands (see help)" 
+local sOUTPUT = "Edit commands (see help)"
 local Cache = {}
 local FS_DATA = gen_table(smartline.NUM_RULES, {})
 
 
 local function output(pos, text, flush_buffer)
 	local meta = minetest.get_meta(pos)
-	if not flush_buffer then 
+	if not flush_buffer then
 		text = meta:get_string("output") .. "\n" .. (text or "")
 		text = text:sub(-500,-1)
 	end
@@ -62,7 +62,7 @@ end
 --		if env.blocked[1] then
 --			env.timer[1] = env.ticks + <after>
 --		end
---		env.conditions[1] = env.blocked[1]	
+--		env.conditions[1] = env.blocked[1]
 --	else
 --		env.conditions[1] = false
 --	end
@@ -77,7 +77,7 @@ end
 --		if env.blocked[1] then
 --			env.timer[1] = env.ticks + <after>
 --		end
---		env.conditions[1] = env.blocked[1]	
+--		env.conditions[1] = env.blocked[1]
 --	else
 --		env.conditions[1] = false
 --	end
@@ -96,7 +96,7 @@ if env.blocked[#] == false and env.ticks %% %s == 0 then
 	if env.blocked[#] then
 		env.timer[#] = env.ticks + %s
 	end
-	env.condition[#] = env.blocked[#]	
+	env.condition[#] = env.blocked[#]
 else
 	env.condition[#] = false
 end
@@ -115,7 +115,7 @@ if env.blocked[#] == false and env.event then
 	if env.blocked[#] then
 		env.timer[#] = env.ticks + %s
 	end
-	env.condition[#] = env.blocked[#]	
+	env.condition[#] = env.blocked[#]
 else
 	env.condition[#] = false
 end
@@ -133,7 +133,7 @@ if env.blocked[#] == false and env.event then
 	if env.blocked[#] then
 		env.timer[#] = env.ticks + %s
 	end
-	env.condition[#] = env.blocked[#]	
+	env.condition[#] = env.blocked[#]
 else
 	env.condition[#] = false
 end
@@ -174,7 +174,7 @@ local function generate(pos, meta, environ)
 		elseif cond == nil and actn ~= nil then
 			output(pos, "Error in condition in rule "..idx)
 		end
-	end 
+	end
 	return table.concat(tbl)
 end
 
@@ -240,7 +240,7 @@ local function battery(pos)
 		return true
 	end
 	return false
-end	
+end
 
 local function start_controller(pos, meta)
 	local number = meta:get_string("number")
@@ -248,10 +248,10 @@ local function start_controller(pos, meta)
 		meta:set_string("formspec", smartline.formspecError(meta))
 		return false
 	end
-	
+
 	meta:set_string("output", "<press update>")
 	meta:set_int("cpu", 0)
-	
+
 	if compile(pos, meta, number) then
 		meta:set_int("state", tubelib.RUNNING)
 		minetest.get_node_timer(pos):start(1)
@@ -301,7 +301,7 @@ local function on_timer(pos, elapsed)
 	local number = meta:get_string("number")
 	if Cache[number] or compile(pos, meta, number) then
 		local res = execute(pos, number, elapsed == -1)
-		if res then 
+		if res then
 			t = minetest.get_us_time() - t
 			if not update_battery(meta, t) then
 				no_battery(pos)
@@ -323,7 +323,7 @@ local function on_receive_fields(pos, formname, fields, player)
 	if player:get_player_name() ~= owner then
 		return
 	end
-	
+
 	--print("fields", dump(fields))
 	if fields.quit then  -- cancel button
 		return
@@ -353,7 +353,7 @@ local function on_receive_fields(pos, formname, fields, player)
 	end
 	if fields._exit_ == "ok" then  -- exit from sub-menu?
 		if fields._button_ then
-			smartline.formspec_button_update(meta, fields)	
+			smartline.formspec_button_update(meta, fields)
 		end
 		-- simulate tab selection
 		fields.tab = "1"
@@ -427,12 +427,12 @@ minetest.register_node("smartline:controller2", {
 			{ -6/32, -6/32, 14/32,  6/32,  6/32, 16/32},
 		},
 	},
-	
+
 	after_place_node = function(pos, placer)
 		local meta = minetest.get_meta(pos)
 		local number = tubelib.add_node(pos, "smartline:controller2")
 		local fs_data = FS_DATA
-		meta:set_string("fs_data", minetest.serialize(fs_data)) 
+		meta:set_string("fs_data", minetest.serialize(fs_data))
 		meta:set_string("owner", placer:get_player_name())
 		meta:set_string("number", number)
 		meta:set_int("state", tubelib.STOPPED)
@@ -442,24 +442,25 @@ minetest.register_node("smartline:controller2", {
 	end,
 
 	on_receive_fields = on_receive_fields,
-	
+
 	on_dig = function(pos, node, puncher, pointed_thing)
 		if minetest.is_protected(pos, puncher:get_player_name()) then
 			return
 		end
-		
+
 		minetest.node_dig(pos, node, puncher, pointed_thing)
 		tubelib.remove_node(pos)
 	end,
-	
+
 	on_timer = on_timer,
-	
+
 	paramtype = "light",
 	sunlight_propagates = true,
 	paramtype2 = "facedir",
 	groups = {choppy=1, cracky=1, crumbly=1},
 	is_ground_content = false,
 	sounds = default.node_sound_stone_defaults(),
+	on_blast = function() end,
 })
 
 
@@ -474,7 +475,7 @@ minetest.register_craft({
 
 -- write inputs from remote nodes
 local function set_input(pos, own_number, rmt_number, val)
-	if rmt_number then 
+	if rmt_number then
 		if Cache[own_number] and Cache[own_number].env.input then
 			local t = minetest.get_us_time()
 			Cache[own_number].env.input[rmt_number] = val
@@ -486,14 +487,14 @@ local function set_input(pos, own_number, rmt_number, val)
 			end
 		end
 	end
-end	
+end
 
 tubelib.register_node("smartline:controller2", {}, {
 	on_recv_message = function(pos, topic, payload)
 		local meta = minetest.get_meta(pos)
 		local number = meta:get_string("number")
 		local state = meta:get_int("state")
-		
+
 		if state == tubelib.RUNNING and topic == "on" then
 			set_input(pos, number, payload, topic)
 		elseif state == tubelib.RUNNING and topic == "off" then
@@ -511,5 +512,4 @@ tubelib.register_node("smartline:controller2", {}, {
 			minetest.get_node_timer(pos):start(1)
 		end
 	end,
-})		
-
+})

--- a/smartline/playerdetector.lua
+++ b/smartline/playerdetector.lua
@@ -9,7 +9,7 @@
 	See LICENSE.txt for more information
 
 	playerdetector.lua:
-	
+
 ]]--
 
 -- Load support for I18n
@@ -42,14 +42,14 @@ local function scan_for_player(pos)
 	local names = meta:get_string("names") or ""
 	for _, object in pairs(minetest.get_objects_inside_radius(pos, 4)) do
 		if object:is_player() then
-			if names == "" then 
+			if names == "" then
 				meta:set_string("player_name", object:get_player_name())
-				return true 
+				return true
 			end
 			for _,name in ipairs(string.split(names, " ")) do
-				if object:get_player_name() == name then 
+				if object:get_player_name() == name then
 					meta:set_string("player_name", name)
-					return true 
+					return true
 				end
 			end
 		end
@@ -141,11 +141,11 @@ minetest.register_node("smartline:playerdetector", {
 	end,
 
 	on_receive_fields = on_receive_fields,
-	
+
 	after_dig_node = function(pos)
 		tubelib.remove_node(pos)
 	end,
-	
+
 	on_timer = function (pos, elapsed)
 		if tubelib.data_not_corrupted(pos) then
 			if scan_for_player(pos) then
@@ -164,6 +164,7 @@ minetest.register_node("smartline:playerdetector", {
 	groups = {cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_metal_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_node("smartline:playerdetector_active", {
@@ -185,9 +186,9 @@ minetest.register_node("smartline:playerdetector_active", {
 			{ -6/32, -6/32, 14/32,  6/32,  6/32, 16/32},
 		},
 	},
-	
+
 	on_receive_fields = on_receive_fields,
-	
+
 	after_dig_node = function(pos)
 		tubelib.remove_node(pos)
 	end,
@@ -206,7 +207,8 @@ minetest.register_node("smartline:playerdetector_active", {
 	groups = {cracky=2, crumbly=2, not_in_creative_inventory=1},
 	is_ground_content = false,
 	sounds = default.node_sound_metal_defaults(),
-	drop = "smartline:playerdetector"
+	drop = "smartline:playerdetector",
+	on_blast = function() end,
 })
 
 minetest.register_craft({
@@ -234,5 +236,4 @@ tubelib.register_node("smartline:playerdetector", {"smartline:playerdetector_act
 	on_node_load = function(pos)
 		minetest.get_node_timer(pos):start(1.0)
 	end,
-})		
-
+})

--- a/smartline/repeater.lua
+++ b/smartline/repeater.lua
@@ -23,7 +23,7 @@ local function formspec(meta)
 	return "size[7,5]"..
 		"field[0.5,2;6,1;number;"..S("Destination node numbers")..";"..numbers.."]" ..
 		"button_exit[1,3;2,1;exit;"..S("Save").."]"
-end	
+end
 
 minetest.register_node("smartline:repeater", {
 	description = S("SmartLine Repeater"),
@@ -63,20 +63,20 @@ minetest.register_node("smartline:repeater", {
 		if owner ~= player:get_player_name() then
 			return
 		end
-		
+
 		if tubelib.check_numbers(fields.number) then
 			meta:set_string("numbers", fields.number)
 			local own_number = meta:get_string("own_number")
 			meta:set_string("infotext", S("SmartLine Repeater").." "..own_number..": "..S("connected with").." "..fields.number)
 			meta:set_string("formspec", formspec(meta))
 		end
-		
+
 		local timer = minetest.get_node_timer(pos)
 		if not timer:is_started() then
 			timer:start(1)
 		end
 	end,
-	
+
 	on_timer = function(pos,elapsed)
 		if tubelib.data_not_corrupted(pos) then
 			local meta = minetest.get_meta(pos)
@@ -85,7 +85,7 @@ minetest.register_node("smartline:repeater", {
 		end
 		return false
 	end,
-	
+
 	after_dig_node = function(pos)
 		tubelib.remove_node(pos)
 	end,
@@ -96,6 +96,7 @@ minetest.register_node("smartline:repeater", {
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_stone_defaults(),
+	on_blast = function() end,
 })
 
 
@@ -133,4 +134,4 @@ tubelib.register_node("smartline:repeater", {}, {
 	on_node_load = function(pos)
 		minetest.get_node_timer(pos):start(1)
 	end,
-})		
+})

--- a/smartline/sequencer.lua
+++ b/smartline/sequencer.lua
@@ -2,7 +2,7 @@
 
 	SmartLine
 	=========
-	
+
 	Copyright (C) 2017-2020 Joachim Stolberg
 
 	AGPL v3
@@ -10,7 +10,7 @@
 
 	sequencer.lua:
 	Derived from Tubelib sequencer
-	
+
 ]]--
 
 -- Load support for I18n
@@ -22,7 +22,7 @@ local NUM_SLOTS = 8
 
 local sHELP = "label[0,0;"..
 S([[SmartLine Sequencer Help
-	
+
 Define a sequence of commands to control other machines.
 Numbers(s) are the node numbers, the command shall sent to.
 The commands 'on'/'off' are used for machines and other nodes.
@@ -44,7 +44,7 @@ local function formspec(state, rules, endless)
 		default.gui_bg_img..
 		default.gui_slots..
 		"label[0,0;"..S("Number(s)").."]label[2.1,0;"..S("Command").."]label[6.4,0;"..S("Offset/s").."]"}
-		
+
 	for idx, rule in ipairs(rules or {}) do
 		tbl[#tbl+1] = "field[0.2,"..(-0.2+idx)..";2,1;num"..idx..";;"..(rule.num or "").."]"
 		tbl[#tbl+1] = "dropdown[2,"..(-0.4+idx)..";3.9,1;act"..idx..";"..sAction..";"..(rule.act or "").."]"
@@ -53,7 +53,7 @@ local function formspec(state, rules, endless)
 	tbl[#tbl+1] = "checkbox[0,8.5;endless;"..S("Run endless")..";"..endless.."]"
 	tbl[#tbl+1] = "button[4.5,8.5;1.5,1;help;"..S("help").."]"
 	tbl[#tbl+1] = "image_button[6.5,8.5;1,1;".. tubelib.state_button(state) ..";button;]"
-	
+
 	return table.concat(tbl)
 end
 
@@ -99,7 +99,7 @@ local function restart_timer(pos, time)
 	if type(time) == "number" then
 		timer:start(time)
 	end
-end	
+end
 
 local function check_rules(pos, elapsed)
 	if tubelib.data_not_corrupted(pos) then
@@ -164,14 +164,14 @@ local function on_receive_fields(pos, formname, fields, player)
 		meta:set_string("formspec", formspec_help())
 		return
 	end
-	
+
 	local endless = meta:get_int("endless") or 0
 	if fields.endless ~= nil then
 		endless = fields.endless == "true" and 1 or 0
 		meta:set_int("index", 1)
 	end
 	meta:set_int("endless", endless)
-	
+
 	local rules = minetest.deserialize(meta:get_string("rules"))
 	if fields.exit ~= nil then
 		meta:set_string("formspec", formspec(tubelib.state(running), rules, endless))
@@ -219,7 +219,7 @@ minetest.register_node("smartline:sequencer", {
 		"smartline.png",
 		"smartline.png^smartline_sequencer.png",
 	},
-	
+
 	drawtype = "nodebox",
 	node_box = {
 		type = "fixed",
@@ -245,7 +245,7 @@ minetest.register_node("smartline:sequencer", {
 	end,
 
 	on_receive_fields = on_receive_fields,
-	
+
 	on_dig = function(pos, node, puncher, pointed_thing)
 		if minetest.is_protected(pos, puncher:get_player_name()) then
 			return
@@ -257,15 +257,16 @@ minetest.register_node("smartline:sequencer", {
 			tubelib.remove_node(pos)
 		end
 	end,
-	
+
 	on_timer = check_rules,
-	
+
 	paramtype = "light",
 	sunlight_propagates = true,
 	paramtype2 = "facedir",
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_stone_defaults(),
+	on_blast = function() end,
 })
 
 
@@ -296,4 +297,4 @@ tubelib.register_node("smartline:sequencer", {}, {
 			minetest.get_node_timer(pos):start(1)
 		end
 	end,
-})		
+})

--- a/smartline/signaltower.lua
+++ b/smartline/signaltower.lua
@@ -20,14 +20,14 @@ local function switch_on(pos, node, color)
 	meta:set_string("state", color)
 	node.name = "smartline:signaltower_"..color
 	minetest.swap_node(pos, node)
-end	
+end
 
 local function switch_off(pos, node)
 	local meta = minetest.get_meta(pos)
 	meta:set_string("state", "off")
 	node.name = "smartline:signaltower"
 	minetest.swap_node(pos, node)
-end	
+end
 
 minetest.register_node("smartline:signaltower", {
 	description = S("SmartLine Signal Tower"),
@@ -44,7 +44,7 @@ minetest.register_node("smartline:signaltower", {
 			{ -5/32, -16/32, -5/32,  5/32,  16/32, 5/32},
 		},
 	},
-	
+
 	after_place_node = function(pos, placer)
 		local number = tubelib.add_node(pos, "smartline:signaltower")
 		local meta = minetest.get_meta(pos)
@@ -63,12 +63,13 @@ minetest.register_node("smartline:signaltower", {
 	end,
 
 	paramtype = "light",
-	light_source = 0,	
+	light_source = 0,
 	sunlight_propagates = true,
 	paramtype2 = "facedir",
 	groups = {cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_glass_defaults(),
+	on_blast = function() end,
 })
 
 for _,color in ipairs({"green", "amber", "red"}) do
@@ -94,13 +95,14 @@ for _,color in ipairs({"green", "amber", "red"}) do
 		end,
 
 		paramtype = "light",
-		light_source = 10,	
+		light_source = 10,
 		sunlight_propagates = true,
 		paramtype2 = "facedir",
 		groups = {crumbly=0, not_in_creative_inventory=1},
 		is_ground_content = false,
 		sounds = default.node_sound_glass_defaults(),
 		drop = "smartline:signaltower",
+		on_blast = function() end,
 	})
 end
 
@@ -114,8 +116,8 @@ minetest.register_craft({
 })
 
 tubelib.register_node("smartline:signaltower", {
-	"smartline:signaltower_green", 
-	"smartline:signaltower_amber", 
+	"smartline:signaltower_green",
+	"smartline:signaltower_amber",
 	"smartline:signaltower_red"}, {
 	on_recv_message = function(pos, topic, payload)
 		local node = minetest.get_node(pos)
@@ -132,4 +134,4 @@ tubelib.register_node("smartline:signaltower", {
 			return meta:get_string("state")
 		end
 	end,
-})		
+})

--- a/smartline/timer.lua
+++ b/smartline/timer.lua
@@ -2,7 +2,7 @@
 
 	SmartLine
 	=========
-	
+
 	Copyright (C) 2017-2020 Joachim Stolberg
 
 	AGPL v3
@@ -10,7 +10,7 @@
 
 	timer.lua:
 	Derived from Tubelib timer
-	
+
 ]]--
 
 -- Load support for I18n
@@ -22,17 +22,17 @@ local sHELP = "label[0,0;"..
 S([[SmartLine Timer Help
 
 The Timer is for a daytime controlled sending of commands
-e.g. to turn street lights on/off. The timer checks the 
-time every few seconds. If the block was just loaded, 
+e.g. to turn street lights on/off. The timer checks the
+time every few seconds. If the block was just loaded,
 the timer will check the last 4 hours for commands
 that still need to be executed.]])..
 "]"
 
 
 local tTime = {
-	["00:00"] = 1, ["02:00"] = 2, ["04:00"] = 3, 
+	["00:00"] = 1, ["02:00"] = 2, ["04:00"] = 3,
 	["06:00"] = 4, ["08:00"] = 5, ["10:00"] = 6,
-	["12:00"] = 7, ["14:00"] = 8, ["16:00"] = 9, 
+	["12:00"] = 7, ["14:00"] = 8, ["16:00"] = 9,
 	["18:00"] =10, ["20:00"] =11, ["22:00"] =12,
 }
 
@@ -51,32 +51,32 @@ local function formspec(events, numbers, actions)
 		default.gui_bg..
 		default.gui_bg_img..
 		default.gui_slots..
-			
+
 		"label[0,0;"..S("Time").."]label[2.3,0;"..S("Number(s)").."]label[4.5,0;"..S("Command").."]"..
-		"dropdown[0,1;2,1;e1;"..sTime..";"..events[1].."]".. 
+		"dropdown[0,1;2,1;e1;"..sTime..";"..events[1].."]"..
 		"field[2.3,1.2;2,1;n1;;"..numbers[1].."]" ..
-		"dropdown[4.5,1;3,1;a1;"..sAction..";"..tAction[actions[1]].."]".. 
-		
-		"dropdown[0,2;2,1;e2;"..sTime..";"..events[2].."]".. 
+		"dropdown[4.5,1;3,1;a1;"..sAction..";"..tAction[actions[1]].."]"..
+
+		"dropdown[0,2;2,1;e2;"..sTime..";"..events[2].."]"..
 		"field[2.3,2.2;2,1;n2;;"..numbers[2].."]" ..
-		"dropdown[4.5,2;3,1;a2;"..sAction..";"..tAction[actions[2]].."]".. 
-		
-		"dropdown[0,3;2,1;e3;"..sTime..";"..events[3].."]".. 
+		"dropdown[4.5,2;3,1;a2;"..sAction..";"..tAction[actions[2]].."]"..
+
+		"dropdown[0,3;2,1;e3;"..sTime..";"..events[3].."]"..
 		"field[2.3,3.2;2,1;n3;;"..numbers[3].."]" ..
-		"dropdown[4.5,3;3,1;a3;"..sAction..";"..tAction[actions[3]].."]".. 
-		
-		"dropdown[0,4;2,1;e4;"..sTime..";"..events[4].."]".. 
+		"dropdown[4.5,3;3,1;a3;"..sAction..";"..tAction[actions[3]].."]"..
+
+		"dropdown[0,4;2,1;e4;"..sTime..";"..events[4].."]"..
 		"field[2.3,4.2;2,1;n4;;"..numbers[4].."]" ..
-		"dropdown[4.5,4;3,1;a4;"..sAction..";"..tAction[actions[4]].."]".. 
-		
-		"dropdown[0,5;2,1;e5;"..sTime..";"..events[5].."]".. 
+		"dropdown[4.5,4;3,1;a4;"..sAction..";"..tAction[actions[4]].."]"..
+
+		"dropdown[0,5;2,1;e5;"..sTime..";"..events[5].."]"..
 		"field[2.3,5.2;2,1;n5;;"..numbers[5].."]" ..
-		"dropdown[4.5,5;3,1;a5;"..sAction..";"..tAction[actions[5]].."]".. 
-		
-		"dropdown[0,6;2,1;e6;"..sTime..";"..events[6].."]".. 
+		"dropdown[4.5,5;3,1;a5;"..sAction..";"..tAction[actions[5]].."]"..
+
+		"dropdown[0,6;2,1;e6;"..sTime..";"..events[6].."]"..
 		"field[2.3,6.2;2,1;n6;;"..numbers[6].."]" ..
-		"dropdown[4.5,6;3,1;a6;"..sAction..";"..tAction[actions[6]].."]".. 
-		
+		"dropdown[4.5,6;3,1;a6;"..sAction..";"..tAction[actions[6]].."]"..
+
 		"button[4.5,7;1.5,1;help;"..S("help").."]"..
 		"button_exit[6.5,7;1.5,1;exit;"..S("close").."]"
 end
@@ -102,7 +102,7 @@ local function check_rules(pos,elapsed)
 		local done = minetest.deserialize(meta:get_string("done"))
 		local placer_name = meta:get_string("placer_name")
 		local own_num = meta:get_string("own_num")
-		
+
 		-- check all rules
 		for idx,act in ipairs(actions) do
 			if act ~= "" and numbers[idx] ~= "" then
@@ -121,7 +121,7 @@ local function check_rules(pos,elapsed)
 				end
 			end
 		end
-		
+
 		-- prepare for the next day
 		if hour == 23 then
 			done = {false,false,false,false,false,false}
@@ -205,12 +205,12 @@ minetest.register_node("smartline:timer", {
 			end
 		end
 		meta:set_string("actions", minetest.serialize(actions))
-	
+
 		meta:set_string("formspec", formspec(events, numbers, actions))
 		local done = {false,false,false,false,false,false}
 		meta:set_string("done",  minetest.serialize(done))
 	end,
-	
+
 	on_timer = check_rules,
 
 	after_dig_node = function(pos)
@@ -223,6 +223,7 @@ minetest.register_node("smartline:timer", {
 	sounds = default.node_sound_stone_defaults(),
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
+	on_blast = function() end,
 })
 
 tubelib.register_node("smartline:timer", {}, {

--- a/techpack_warehouse/box_copper.lua
+++ b/techpack_warehouse/box_copper.lua
@@ -7,7 +7,7 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	box_copper.lua
 
 ]]--
@@ -23,20 +23,20 @@ local wh = techpack_warehouse
 local NODE_NAME = "techpack_warehouse:box_copper"
 local DESCRIPTION = S("Warehouse Box Copper")
 local INV_SIZE = 1200
-local BACKGROUND_IMG = "default_copper_block.png" 
+local BACKGROUND_IMG = "default_copper_block.png"
 
 
 local Box = wh.Box:new({
-	node_name = NODE_NAME, 
-	description = DESCRIPTION, 
-	inv_size = INV_SIZE, 
+	node_name = NODE_NAME,
+	description = DESCRIPTION,
+	inv_size = INV_SIZE,
 	background_img = BACKGROUND_IMG,
-}) 
+})
 
 minetest.register_node(NODE_NAME, {
 	description = DESCRIPTION.." (8 x "..INV_SIZE.." items)",
 	tiles = wh.tiles(BACKGROUND_IMG),
-	
+
 	after_place_node = function(pos, placer, itemstack)
 		return wh.after_place_node(Box, pos, placer, itemstack)
 	end,
@@ -58,7 +58,7 @@ minetest.register_node(NODE_NAME, {
 	on_metadata_inventory_put = wh.on_metadata_inventory_put,
 	allow_metadata_inventory_take = wh.allow_metadata_inventory_take,
 	allow_metadata_inventory_move = wh.allow_metadata_inventory_move,
-	
+
 	on_rotate = screwdriver.disallow,
 	paramtype = "light",
 	sunlight_propagates = true,
@@ -66,12 +66,13 @@ minetest.register_node(NODE_NAME, {
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_metal_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_node(NODE_NAME.."_active", {
 	description = DESCRIPTION.." (8 x "..INV_SIZE.." items)",
 	tiles = wh.tiles_active(BACKGROUND_IMG),
-	
+
 	after_place_node = function(pos, placer, itemstack)
 		return wh.after_place_node(Box, pos, placer, itemstack)
 	end,
@@ -87,10 +88,10 @@ minetest.register_node(NODE_NAME.."_active", {
 	on_metadata_inventory_put = wh.on_metadata_inventory_put,
 	allow_metadata_inventory_take = wh.allow_metadata_inventory_take,
 	allow_metadata_inventory_move = wh.allow_metadata_inventory_move,
-  
+
 	diggable = false,
 	can_dig = function() return false end,
-	
+
 	on_rotate = screwdriver.disallow,
 	paramtype = "light",
 	sunlight_propagates = true,
@@ -98,12 +99,13 @@ minetest.register_node(NODE_NAME.."_active", {
 	groups = {crumbly=0, not_in_creative_inventory=1},
 	is_ground_content = false,
 	sounds = default.node_sound_metal_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_node(NODE_NAME.."_defect", {
 	description = DESCRIPTION.." (8 x "..INV_SIZE.." items)",
 	tiles = wh.tiles_defect(BACKGROUND_IMG),
-	
+
 	after_place_node = function(pos, placer, itemstack)
 		wh.after_place_node(Box, pos, placer, itemstack)
 		Box.State:defect(pos, M(pos))
@@ -120,7 +122,7 @@ minetest.register_node(NODE_NAME.."_defect", {
 	on_metadata_inventory_put = wh.on_metadata_inventory_put,
 	allow_metadata_inventory_take = wh.allow_metadata_inventory_take,
 	allow_metadata_inventory_move = wh.allow_metadata_inventory_move,
-	
+
 	on_rotate = screwdriver.disallow,
 	paramtype = "light",
 	sunlight_propagates = true,
@@ -128,9 +130,10 @@ minetest.register_node(NODE_NAME.."_defect", {
 	groups = {choppy=2, cracky=2, crumbly=2, not_in_creative_inventory=1},
 	is_ground_content = false,
 	sounds = default.node_sound_metal_defaults(),
+	on_blast = function() end,
 })
 
-tubelib.register_node(NODE_NAME, 
+tubelib.register_node(NODE_NAME,
 	{NODE_NAME.."_active", NODE_NAME.."_defect"}, {
 	on_push_item = function(pos, side, item)
 		local meta = M(pos)
@@ -175,7 +178,7 @@ tubelib.register_node(NODE_NAME,
 	on_node_repair = function(pos)
 		return Box.State:on_node_repair(pos)
 	end,
-})	
+})
 
 minetest.register_craft({
 	output = NODE_NAME,

--- a/techpack_warehouse/box_gold.lua
+++ b/techpack_warehouse/box_gold.lua
@@ -7,7 +7,7 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	box_gold.lua
 
 ]]--
@@ -23,20 +23,20 @@ local wh = techpack_warehouse
 local NODE_NAME = "techpack_warehouse:box_gold"
 local DESCRIPTION = S("Warehouse Box Gold")
 local INV_SIZE = 3600
-local BACKGROUND_IMG = "default_gold_block.png" 
+local BACKGROUND_IMG = "default_gold_block.png"
 
 
 local Box = wh.Box:new({
-	node_name = NODE_NAME, 
-	description = DESCRIPTION, 
-	inv_size = INV_SIZE, 
+	node_name = NODE_NAME,
+	description = DESCRIPTION,
+	inv_size = INV_SIZE,
 	background_img = BACKGROUND_IMG,
-}) 
+})
 
 minetest.register_node(NODE_NAME, {
 	description = DESCRIPTION.." (8 x "..INV_SIZE.." items)",
 	tiles = wh.tiles(BACKGROUND_IMG),
-	
+
 	after_place_node = function(pos, placer, itemstack)
 		return wh.after_place_node(Box, pos, placer, itemstack)
 	end,
@@ -58,7 +58,7 @@ minetest.register_node(NODE_NAME, {
 	on_metadata_inventory_put = wh.on_metadata_inventory_put,
 	allow_metadata_inventory_take = wh.allow_metadata_inventory_take,
 	allow_metadata_inventory_move = wh.allow_metadata_inventory_move,
-	
+
 	on_rotate = screwdriver.disallow,
 	paramtype = "light",
 	sunlight_propagates = true,
@@ -66,12 +66,13 @@ minetest.register_node(NODE_NAME, {
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_metal_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_node(NODE_NAME.."_active", {
 	description = DESCRIPTION.." (8 x "..INV_SIZE.." items)",
 	tiles = wh.tiles_active(BACKGROUND_IMG),
-	
+
 	after_place_node = function(pos, placer, itemstack)
 		return wh.after_place_node(Box, pos, placer, itemstack)
 	end,
@@ -87,10 +88,10 @@ minetest.register_node(NODE_NAME.."_active", {
 	on_metadata_inventory_put = wh.on_metadata_inventory_put,
 	allow_metadata_inventory_take = wh.allow_metadata_inventory_take,
 	allow_metadata_inventory_move = wh.allow_metadata_inventory_move,
-	
+
 	diggable = false,
 	can_dig = function() return false end,
-	
+
 	on_rotate = screwdriver.disallow,
 	paramtype = "light",
 	sunlight_propagates = true,
@@ -98,12 +99,13 @@ minetest.register_node(NODE_NAME.."_active", {
 	groups = {crumbly=0, not_in_creative_inventory=1},
 	is_ground_content = false,
 	sounds = default.node_sound_metal_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_node(NODE_NAME.."_defect", {
 	description = DESCRIPTION.." (8 x "..INV_SIZE.." items)",
 	tiles = wh.tiles_defect(BACKGROUND_IMG),
-	
+
 	after_place_node = function(pos, placer, itemstack)
 		wh.after_place_node(Box, pos, placer, itemstack)
 		Box.State:defect(pos, M(pos))
@@ -120,7 +122,7 @@ minetest.register_node(NODE_NAME.."_defect", {
 	on_metadata_inventory_put = wh.on_metadata_inventory_put,
 	allow_metadata_inventory_take = wh.allow_metadata_inventory_take,
 	allow_metadata_inventory_move = wh.allow_metadata_inventory_move,
-	
+
 	on_rotate = screwdriver.disallow,
 	paramtype = "light",
 	sunlight_propagates = true,
@@ -128,9 +130,10 @@ minetest.register_node(NODE_NAME.."_defect", {
 	groups = {choppy=2, cracky=2, crumbly=2, not_in_creative_inventory=1},
 	is_ground_content = false,
 	sounds = default.node_sound_metal_defaults(),
+	on_blast = function() end,
 })
 
-tubelib.register_node(NODE_NAME, 
+tubelib.register_node(NODE_NAME,
 	{NODE_NAME.."_active", NODE_NAME.."_defect"}, {
 	on_push_item = function(pos, side, item)
 		local meta = M(pos)
@@ -175,7 +178,7 @@ tubelib.register_node(NODE_NAME,
 	on_node_repair = function(pos)
 		return Box.State:on_node_repair(pos)
 	end,
-})	
+})
 
 minetest.register_craft({
 	output = NODE_NAME,

--- a/techpack_warehouse/box_steel.lua
+++ b/techpack_warehouse/box_steel.lua
@@ -7,7 +7,7 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	box_steel.lua
 
 ]]--
@@ -23,20 +23,20 @@ local wh = techpack_warehouse
 local NODE_NAME = "techpack_warehouse:box_steel"
 local DESCRIPTION = S("Warehouse Box Steel")
 local INV_SIZE = 400
-local BACKGROUND_IMG = "default_steel_block.png" 
+local BACKGROUND_IMG = "default_steel_block.png"
 
 
 local Box = wh.Box:new({
-	node_name = NODE_NAME, 
-	description = DESCRIPTION, 
-	inv_size = INV_SIZE, 
+	node_name = NODE_NAME,
+	description = DESCRIPTION,
+	inv_size = INV_SIZE,
 	background_img = BACKGROUND_IMG,
-}) 
+})
 
 minetest.register_node(NODE_NAME, {
 	description = DESCRIPTION.." (8 x "..INV_SIZE.." items)",
 	tiles = wh.tiles(BACKGROUND_IMG),
-	
+
 	after_place_node = function(pos, placer, itemstack)
 		return wh.after_place_node(Box, pos, placer, itemstack)
 	end,
@@ -58,7 +58,7 @@ minetest.register_node(NODE_NAME, {
 	on_metadata_inventory_put = wh.on_metadata_inventory_put,
 	allow_metadata_inventory_take = wh.allow_metadata_inventory_take,
 	allow_metadata_inventory_move = wh.allow_metadata_inventory_move,
-	
+
 	on_rotate = screwdriver.disallow,
 	paramtype = "light",
 	sunlight_propagates = true,
@@ -66,12 +66,13 @@ minetest.register_node(NODE_NAME, {
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_metal_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_node(NODE_NAME.."_active", {
 	description = DESCRIPTION.." (8 x "..INV_SIZE.." items)",
 	tiles = wh.tiles_active(BACKGROUND_IMG),
-	
+
 	after_place_node = function(pos, placer, itemstack)
 		return wh.after_place_node(Box, pos, placer, itemstack)
 	end,
@@ -87,10 +88,10 @@ minetest.register_node(NODE_NAME.."_active", {
 	on_metadata_inventory_put = wh.on_metadata_inventory_put,
 	allow_metadata_inventory_take = wh.allow_metadata_inventory_take,
 	allow_metadata_inventory_move = wh.allow_metadata_inventory_move,
-  
+
 	diggable = false,
 	can_dig = function() return false end,
-	
+
 	on_rotate = screwdriver.disallow,
 	paramtype = "light",
 	sunlight_propagates = true,
@@ -98,12 +99,13 @@ minetest.register_node(NODE_NAME.."_active", {
 	groups = {crumbly=0, not_in_creative_inventory=1},
 	is_ground_content = false,
 	sounds = default.node_sound_metal_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_node(NODE_NAME.."_defect", {
 	description = DESCRIPTION.." (8 x "..INV_SIZE.." items)",
 	tiles = wh.tiles_defect(BACKGROUND_IMG),
-	
+
 	after_place_node = function(pos, placer, itemstack)
 		wh.after_place_node(Box, pos, placer, itemstack)
 		Box.State:defect(pos, M(pos))
@@ -120,7 +122,7 @@ minetest.register_node(NODE_NAME.."_defect", {
 	on_metadata_inventory_put = wh.on_metadata_inventory_put,
 	allow_metadata_inventory_take = wh.allow_metadata_inventory_take,
 	allow_metadata_inventory_move = wh.allow_metadata_inventory_move,
-	
+
 	on_rotate = screwdriver.disallow,
 	paramtype = "light",
 	sunlight_propagates = true,
@@ -128,9 +130,10 @@ minetest.register_node(NODE_NAME.."_defect", {
 	groups = {choppy=2, cracky=2, crumbly=2, not_in_creative_inventory=1},
 	is_ground_content = false,
 	sounds = default.node_sound_metal_defaults(),
+	on_blast = function() end,
 })
 
-tubelib.register_node(NODE_NAME, 
+tubelib.register_node(NODE_NAME,
 	{NODE_NAME.."_active", NODE_NAME.."_defect"}, {
 	on_push_item = function(pos, side, item)
 		local meta = M(pos)
@@ -175,7 +178,7 @@ tubelib.register_node(NODE_NAME,
 	on_node_repair = function(pos)
 		return Box.State:on_node_repair(pos)
 	end,
-})	
+})
 
 minetest.register_craft({
 	output = NODE_NAME,

--- a/tubelib/blackhole.lua
+++ b/tubelib/blackhole.lua
@@ -9,17 +9,17 @@
 	See LICENSE.txt for more information
 
 	blackhole.lua:
-	
+
 	Simple node which lets all items disappear.
 	The blackhole supports the following message:
-	- topic = "status", payload  = nil, 
+	- topic = "status", payload  = nil,
 	  response is the number of disappeared items (0..n)
 ]]--
 
 --                 +--------+
 --                /        /|
 --               +--------+ |
---     IN (L) -->|  BLACK | |          
+--     IN (L) -->|  BLACK | |
 --               |  HOLE  | +
 --               |        |/
 --               +--------+
@@ -58,6 +58,7 @@ minetest.register_node("tubelib:blackhole", {
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 
@@ -75,7 +76,7 @@ minetest.register_craft({
 tubelib.register_node("tubelib:blackhole", {}, {
 	on_pull_item = nil,  		-- not needed
 	on_unpull_item = nil,		-- not needed
-	
+
 	valid_sides = {"L"},
 	on_push_item = function(pos, side, item)
 		local meta = minetest.get_meta(pos)
@@ -84,7 +85,7 @@ tubelib.register_node("tubelib:blackhole", {}, {
 		meta:set_string("infotext", disappeared.." "..S("items disappeared"))
 		return true
 	end,
-	
+
 	on_recv_message = function(pos, topic, payload)
 		local node = minetest.get_node(pos)
 		if topic == "state" then
@@ -94,5 +95,5 @@ tubelib.register_node("tubelib:blackhole", {}, {
 			return "not supported"
 		end
 	end,
-})	
+})
 --------------------------------------------------------------- tubelib

--- a/tubelib/button.lua
+++ b/tubelib/button.lua
@@ -9,7 +9,7 @@
 	See LICENSE.txt for more information
 
 	button.lua:
-	
+
 	Example of a simple communication node, only sending messages to other nodes.
 
 ]]--
@@ -83,7 +83,7 @@ minetest.register_node("tubelib:button", {
 		local own_num = tubelib.add_node(pos, "tubelib:button")
 		meta:set_string("own_num", own_num)
 		meta:set_string("formspec", "size[7.5,6]"..
-		"dropdown[0.2,0;3;type;"..S("switch,button 2s,button 4s,button 8s,button 16s")..";1]".. 
+		"dropdown[0.2,0;3;type;"..S("switch,button 2s,button 4s,button 8s,button 16s")..";1]"..
 		"field[0.5,2;7,1;numbers;"..S("Insert destination node number(s)")..";]" ..
 		"checkbox[1,3;public;"..S("public")..";false]"..
 		"button_exit[2,4;3,1;exit;"..S("Save").."]")
@@ -124,7 +124,7 @@ minetest.register_node("tubelib:button", {
 			meta:set_string("formspec", nil)
 		end
 	end,
-	
+
 	on_rightclick = function(pos, node, clicker)
 		local meta = minetest.get_meta(pos)
 		if meta:get_string("numbers") ~= "" and meta:get_string("numbers") ~= nil then
@@ -140,6 +140,7 @@ minetest.register_node("tubelib:button", {
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 
@@ -173,6 +174,7 @@ minetest.register_node("tubelib:button_active", {
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
 	drop = "tubelib:button",
+	on_blast = function() end,
 })
 
 tubelib.register_node("tubelib:button", {"tubelib:button_active"}, {tubelib_node = true})
@@ -185,4 +187,3 @@ minetest.register_craft({
 		{"",              "group:wood",  	    ""},
 	},
 })
-

--- a/tubelib/defect.lua
+++ b/tubelib/defect.lua
@@ -13,6 +13,7 @@ minetest.register_node("tubelib:defect_dummy", {
 	},
 	groups = {cracky=3, crumbly=3, choppy=3, not_in_creative_inventory=1},
 	is_ground_content = false,
+	on_blast = function() end,
 })
 
 local reported_machines = {}
@@ -25,7 +26,7 @@ local function already_reported(pos)
 end
 
 
-function tubelib.data_not_corrupted(pos, has_no_info)	
+function tubelib.data_not_corrupted(pos, has_no_info)
 	if minetest.pos_to_string(pos) ~= minetest.get_meta(pos):get_string("my_pos") then
 		-- node number corrupt?
 		local meta = minetest.get_meta(pos)
@@ -45,13 +46,13 @@ function tubelib.data_not_corrupted(pos, has_no_info)
 				report(pos)
 			end
 		end
-		
+
 		-- button like odes
-		if has_no_info then 
+		if has_no_info then
 			minetest.get_meta(pos):get_string("my_pos", minetest.pos_to_string(pos))
-			return true 
+			return true
 		end
-		
+
 		-- node moved?
 		local info = tubelib.get_node_info(number)
 		if not info or not vector.equals(info.pos, pos) then

--- a/tubelib/forceload.lua
+++ b/tubelib/forceload.lua
@@ -9,7 +9,7 @@
 	See LICENSE.txt for more information
 
 	forceload.lua:
-	
+
 ]]--
 
 -- Load support for I18n
@@ -41,7 +41,7 @@ end
 local function remove_list_elem(list, x)
 	local n = nil
 	for idx, v in ipairs(list) do
-		if vector.equals(v, x) then 
+		if vector.equals(v, x) then
 			n = idx
 			break
 		end
@@ -83,7 +83,7 @@ local function add_pos(pos, player)
 	end
 	return false
 end
-	
+
 local function del_pos(pos, player)
 	local lPos = minetest.deserialize(player:get_attribute("tubelib_forceload_blocks")) or {}
 	lPos = remove_list_elem(lPos, pos)
@@ -113,7 +113,7 @@ local function formspec(player)
 	default.gui_bg_img..
 	default.gui_slots..
 	"label[0,0;"..S("List of your Forceload Blocks")..":]"
-	
+
 	for idx,pos in ipairs(lPos) do
 		local pos1, pos2 = calc_area(pos)
 		local ypos = 0.2 + idx * 0.4
@@ -168,7 +168,7 @@ minetest.register_node("tubelib:forceload", {
 		minetest.forceload_free_block(pos, true)
 		tubelib.unmark_region(oldmetadata.fields.owner)
 	end,
-	
+
 	on_rightclick = function(pos, node, clicker, itemstack, pointed_thing)
 		if M(pos):get_string("owner") == clicker:get_player_name() or
 				minetest.check_player_privs(clicker:get_player_name(), "server") then
@@ -176,7 +176,7 @@ minetest.register_node("tubelib:forceload", {
 			minetest.show_formspec(clicker:get_player_name(), "tubelib:forceload", s)
 		end
 	end,
-	
+
 	on_punch = function(pos, node, puncher, pointed_thing)
 		local pos1, pos2 = calc_area(pos)
 		tubelib.switch_region(puncher:get_player_name(), pos1, pos2)
@@ -184,10 +184,11 @@ minetest.register_node("tubelib:forceload", {
 
 	paramtype = "light",
 	sunlight_propagates = true,
-	groups = {choppy=2, cracky=2, crumbly=2, 
+	groups = {choppy=2, cracky=2, crumbly=2,
 		not_in_creative_inventory = tubelib.max_num_forceload_blocks == 0 and 1 or 0},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 

--- a/tubelib/lamp.lua
+++ b/tubelib/lamp.lua
@@ -9,7 +9,7 @@
 	See LICENSE.txt for more information
 
 	lamp.lua:
-	
+
 	Example of a simple communication node, only receiving messages from others.
 	This node claims a position number and registers its message interface.
 	The Lamp supports the following messages:
@@ -24,12 +24,12 @@ local S = tubelib.S
 local function switch_on(pos, node)
 	node.name = "tubelib:lamp_on"
 	minetest.swap_node(pos, node)
-end	
+end
 
 local function switch_off(pos, node)
 	node.name = "tubelib:lamp"
 	minetest.swap_node(pos, node)
-end	
+end
 
 minetest.register_node("tubelib:lamp", {
 	description = S("Tubelib Lamp"),
@@ -54,12 +54,13 @@ minetest.register_node("tubelib:lamp", {
 	end,
 
 	paramtype = "light",
-	light_source = 0,	
+	light_source = 0,
 	sunlight_propagates = true,
 	paramtype2 = "facedir",
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_node("tubelib:lamp_on", {
@@ -75,12 +76,13 @@ minetest.register_node("tubelib:lamp_on", {
 	end,
 
 	paramtype = "light",
-	light_source = minetest.LIGHT_MAX,	
+	light_source = minetest.LIGHT_MAX,
 	sunlight_propagates = true,
 	paramtype2 = "facedir",
 	groups = {crumbly=0, not_in_creative_inventory=1},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_craft({
@@ -105,5 +107,5 @@ tubelib.register_node("tubelib:lamp", {"tubelib:lamp_on"}, {
 			switch_off(pos, node)
 		end
 	end,
-})		
+})
 --------------------------------------------------------------- tubelib

--- a/tubelib/migrate.lua
+++ b/tubelib/migrate.lua
@@ -89,7 +89,7 @@ minetest.register_node("tubelib:tube1", {
 		"tubelib_hole.png",
 		"tubelib_hole.png",
 	},
-	
+
 	after_place_node = function(pos, placer, itemstack, pointed_thing)
 		if not Tube:after_place_tube(pos, placer, pointed_thing) then
 			minetest.remove_node(pos)
@@ -97,11 +97,11 @@ minetest.register_node("tubelib:tube1", {
 		end
 		return false
 	end,
-	
+
 	after_dig_node = function(pos, oldnode, oldmetadata, digger)
 		Tube:after_dig_tube(pos, oldnode, oldmetadata)
 	end,
-	
+
 	paramtype2 = "facedir",
 	drawtype = "nodebox",
 	node_box = {
@@ -124,6 +124,7 @@ minetest.register_node("tubelib:tube1", {
 	is_ground_content = false,
 	groups = {choppy=2, cracky=3, stone=1, not_in_creative_inventory=1},
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_craft({

--- a/tubelib/pusher.lua
+++ b/tubelib/pusher.lua
@@ -9,14 +9,14 @@
 	See LICENSE.txt for more information
 
 	pusher.lua:
-	
+
 	Simple node for push/pull operation of StackItems from chests or other
 	inventory/server nodes to tubes or other inventory/server nodes.
-	
+
 	The Pusher is based on the class NodeStates and supports the following messages:
 	 - topic = "on", payload  = nil
 	 - topic = "off", payload  = nil
-	 - topic = "state", payload  = nil, 
+	 - topic = "state", payload  = nil,
 	   response is "running", "stopped", "standby", "blocked", or "not supported"
 
 ]]--
@@ -78,7 +78,7 @@ local function keep_running(pos, elapsed)
 		return State:is_active(meta)
 	end
 	return false
-end	
+end
 
 minetest.register_node("tubelib:pusher", {
 	description = S("Tubelib Pusher"),
@@ -109,7 +109,7 @@ minetest.register_node("tubelib:pusher", {
 		State:on_dig_node(pos, node, player)
 		tubelib.remove_node(pos)
 	end,
-	
+
 	on_timer = keep_running,
 	on_rotate = screwdriver.disallow,
 
@@ -119,6 +119,7 @@ minetest.register_node("tubelib:pusher", {
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 
@@ -175,7 +176,7 @@ minetest.register_node("tubelib:pusher_active", {
 			State:stop(pos, M(pos))
 		end
 	end,
-	
+
 	on_timer = keep_running,
 	on_rotate = screwdriver.disallow,
 
@@ -188,6 +189,7 @@ minetest.register_node("tubelib:pusher_active", {
 	groups = {crumbly=0, not_in_creative_inventory=1},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_node("tubelib:pusher_defect", {
@@ -213,7 +215,7 @@ minetest.register_node("tubelib:pusher_defect", {
 	after_dig_node = function(pos)
 		tubelib.remove_node(pos) -- <<=== tubelib
 	end,
-	
+
 	on_timer = keep_running,
 	on_rotate = screwdriver.disallow,
 
@@ -223,6 +225,7 @@ minetest.register_node("tubelib:pusher_defect", {
 	groups = {choppy=2, cracky=2, crumbly=2, not_in_creative_inventory=1},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 
@@ -236,7 +239,7 @@ minetest.register_craft({
 })
 
 --------------------------------------------------------------- tubelib
-tubelib.register_node("tubelib:pusher", 
+tubelib.register_node("tubelib:pusher",
 	{"tubelib:pusher_active", "tubelib:pusher_defect"}, {
 	on_pull_item = nil,  		-- pusher has no inventory
 	on_push_item = nil,			-- pusher has no inventory
@@ -257,5 +260,5 @@ tubelib.register_node("tubelib:pusher",
 	on_node_repair = function(pos)
 		return State:on_node_repair(pos)
 	end,
-})	
+})
 --------------------------------------------------------------- tubelib

--- a/tubelib_addons1/autocrafter.lua
+++ b/tubelib_addons1/autocrafter.lua
@@ -8,11 +8,11 @@
 	AGPL v3
 	See LICENSE.txt for more information
 
-	The autocrafter is derived from pipeworks: 
+	The autocrafter is derived from pipeworks:
 	Copyright (C) 2004 Sam Hocevar <sam@hocevar.net>  WTFPL
 
 	autocrafter.lua:
-	
+
 ]]--
 
 -- Load support for I18n
@@ -77,7 +77,7 @@ local function count_index(invlist)
 end
 
 -- caches some recipe data
-local autocrafterCache = {}  
+local autocrafterCache = {}
 
 local function get_craft(pos, inventory, hash)
 	hash = hash or minetest.hash_node_position(pos)
@@ -86,7 +86,7 @@ local function get_craft(pos, inventory, hash)
 		local recipe = inventory:get_list("recipe")
 		local output, decremented_input = minetest.get_craft_result(
 				{method = "normal", width = 3, items = recipe})
-		craft = {recipe = recipe, consumption=count_index(recipe), 
+		craft = {recipe = recipe, consumption=count_index(recipe),
 				output = output, decremented_input = decremented_input}
 		autocrafterCache[hash] = craft
 	end
@@ -98,7 +98,7 @@ local function autocraft(pos, meta, inventory, craft)
 	local output_item = craft.output.item
 
 	-- check if we have enough room in dst
-	if not inventory:room_for_item("dst", output_item) then	
+	if not inventory:room_for_item("dst", output_item) then
 		State:blocked(pos, meta)
 		return
 	end
@@ -106,9 +106,9 @@ local function autocraft(pos, meta, inventory, craft)
 	local inv_index = count_index(inventory:get_list("src"))
 	-- check if we have enough material available
 	for itemname, number in pairs(consumption) do
-		if (not inv_index[itemname]) or inv_index[itemname] < number then 
+		if (not inv_index[itemname]) or inv_index[itemname] < number then
 			State:idle(pos, meta)
-			return 
+			return
 		end
 	end
 	-- consume material
@@ -123,7 +123,7 @@ local function autocraft(pos, meta, inventory, craft)
 	for i = 1, 9 do
 		inventory:add_item("dst", craft.decremented_input.items[i])
 	end
-	
+
 	State:keep_running(pos, meta, COUNTDOWN_TICKS, output_item:get_count())
 end
 
@@ -292,10 +292,10 @@ minetest.register_node("tubelib_addons1:autocrafter", {
 	description = S("Tubelib Autocrafter"),
 	drawtype = "normal",
 	tiles = {
-		'tubelib_front.png', 
-		'tubelib_front.png', 
+		'tubelib_front.png',
+		'tubelib_front.png',
 		'tubelib_addons1_autocrafter.png'},
-	
+
 	after_place_node = function(pos, placer)
 		local number = tubelib.add_node(pos, "tubelib_addons1:autocrafter")
 		State:node_init(pos, number)
@@ -305,7 +305,7 @@ minetest.register_node("tubelib_addons1:autocrafter", {
 		inv:set_size("dst", 3*3)
 		inv:set_size("output", 1)
 	end,
-	
+
 	can_dig = function(pos, player)
 		if minetest.is_protected(pos, player:get_player_name()) then
 			return false
@@ -319,11 +319,11 @@ minetest.register_node("tubelib_addons1:autocrafter", {
 		State:on_dig_node(pos, node, player)
 		tubelib.remove_node(pos)
 	end,
-	
+
 	on_rotate = screwdriver.disallow,
 	on_timer = keep_running,
 	on_receive_fields = on_receive_fields,
-	
+
 	allow_metadata_inventory_put = allow_metadata_inventory_put,
 	allow_metadata_inventory_take = allow_metadata_inventory_take,
 	allow_metadata_inventory_move = allow_metadata_inventory_move,
@@ -334,14 +334,15 @@ minetest.register_node("tubelib_addons1:autocrafter", {
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_node("tubelib_addons1:autocrafter_active", {
 	description = S("Tubelib Autocrafter"),
 	drawtype = "normal",
 	tiles = {
-		'tubelib_front.png', 
-		'tubelib_front.png', 
+		'tubelib_front.png',
+		'tubelib_front.png',
 		{
 			image = 'tubelib_addons1_autocrafter_active.png',
 			backface_culling = false,
@@ -356,7 +357,7 @@ minetest.register_node("tubelib_addons1:autocrafter_active", {
 
 	diggable = false,
 	can_dig = function() return false end,
-	
+
 	on_rotate = screwdriver.disallow,
 	on_timer = keep_running,
 	on_receive_fields = on_receive_fields,
@@ -370,17 +371,18 @@ minetest.register_node("tubelib_addons1:autocrafter_active", {
 	groups = {crumbly=0, not_in_creative_inventory=1},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_node("tubelib_addons1:autocrafter_defect", {
 	description = S("Tubelib Autocrafter"),
 	drawtype = "normal",
 	tiles = {
-		'tubelib_front.png', 
+		'tubelib_front.png',
 		'tubelib_front.png',
 		'tubelib_addons1_autocrafter.png^tubelib_defect.png'
 	},
-	
+
 	after_place_node = function(pos, placer)
 		local number = tubelib.add_node(pos, "tubelib_addons1:autocrafter")
 		State:node_init(pos, number)
@@ -392,7 +394,7 @@ minetest.register_node("tubelib_addons1:autocrafter_defect", {
 		inv:set_size("output", 1)
 		State:defect(pos, meta)
 	end,
-	
+
 	can_dig = function(pos, player)
 		if minetest.is_protected(pos, player:get_player_name()) then
 			return false
@@ -416,6 +418,7 @@ minetest.register_node("tubelib_addons1:autocrafter_defect", {
 	groups = {choppy=2, cracky=2, crumbly=2, not_in_creative_inventory=1},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_craft({
@@ -428,7 +431,7 @@ minetest.register_craft({
 })
 
 
-tubelib.register_node("tubelib_addons1:autocrafter", 
+tubelib.register_node("tubelib_addons1:autocrafter",
 	{"tubelib_addons1:autocrafter_active", "tubelib_addons1:autocrafter_defect"}, {
 	on_pull_stack = function(pos, side)
 		return tubelib.get_stack(M(pos), "dst")
@@ -456,4 +459,4 @@ tubelib.register_node("tubelib_addons1:autocrafter",
 	on_node_repair = function(pos)
 		return State:on_node_repair(pos)
 	end,
-})	
+})

--- a/tubelib_addons1/chest.lua
+++ b/tubelib_addons1/chest.lua
@@ -7,7 +7,7 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	chest.lua
 
 ]]--
@@ -25,7 +25,7 @@ local function store_action(pos, player, action, stack)
 	local number = meta:get_string("number")
 	local item = stack:get_name().." "..stack:get_count()
 	PlayerActions[number] = {name, action, item}
-end	
+end
 
 local function send_off_command(pos)
 	local meta = minetest.get_meta(pos)
@@ -93,7 +93,7 @@ minetest.register_node("tubelib_addons1:chest", {
 		local inv = meta:get_inventory()
 		inv:set_size('main', 32)
 	end,
-	
+
 	after_place_node = function(pos, placer)
 		local meta = minetest.get_meta(pos)
 		local number = tubelib.add_node(pos, "tubelib_addons1:chest")
@@ -114,7 +114,7 @@ minetest.register_node("tubelib_addons1:chest", {
 	after_dig_node = function(pos, oldnode, oldmetadata, digger)
 		tubelib.remove_node(pos)
 	end,
-	
+
 	allow_metadata_inventory_put = allow_metadata_inventory_put,
 	allow_metadata_inventory_take = allow_metadata_inventory_take,
 
@@ -124,6 +124,7 @@ minetest.register_node("tubelib_addons1:chest", {
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 
@@ -146,7 +147,7 @@ tubelib.register_node("tubelib_addons1:chest", {}, {
 		local meta = minetest.get_meta(pos)
 		return tubelib.put_item(meta, "main", item)
 	end,
-	
+
 	on_recv_message = function(pos, topic, payload)
 		if topic == "state" then
 			local meta = minetest.get_meta(pos)
@@ -167,4 +168,4 @@ tubelib.register_node("tubelib_addons1:chest", {}, {
 			return "unsupported"
 		end
 	end,
-})	
+})

--- a/tubelib_addons1/detector.lua
+++ b/tubelib_addons1/detector.lua
@@ -91,6 +91,7 @@ minetest.register_node("tubelib_addons1:detector", {
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 
@@ -121,6 +122,7 @@ minetest.register_node("tubelib_addons1:detector_active", {
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
 	drop = "tubelib_addons1:detector",
+	on_blast = function() end,
 })
 
 minetest.register_craft({
@@ -146,4 +148,3 @@ tubelib.register_node("tubelib_addons1:detector", {"tubelib_addons1:detector_act
 	end,
 	is_pusher = true,  -- is a pulling/pushing node
 })
-

--- a/tubelib_addons1/fermenter.lua
+++ b/tubelib_addons1/fermenter.lua
@@ -230,6 +230,7 @@ minetest.register_node("tubelib_addons1:fermenter", {
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_metal_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_node("tubelib_addons1:fermenter_defect", {
@@ -302,6 +303,7 @@ minetest.register_node("tubelib_addons1:fermenter_defect", {
 	groups = {choppy=2, cracky=2, crumbly=2, not_in_creative_inventory=1},
 	is_ground_content = false,
 	sounds = default.node_sound_metal_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_node("tubelib_addons1:fermenter_top", {
@@ -322,6 +324,7 @@ minetest.register_node("tubelib_addons1:fermenter_top", {
 	groups = {crumbly=0, not_in_creative_inventory=1},
 	is_ground_content = false,
 	pointable = false,
+	on_blast = function() end,
 })
 
 minetest.register_craftitem("tubelib_addons1:biogas", {

--- a/tubelib_addons1/funnel.lua
+++ b/tubelib_addons1/funnel.lua
@@ -7,9 +7,9 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	funnel.lua
-	
+
 ]]--
 
 -- Load support for I18n
@@ -56,7 +56,7 @@ local function scan_for_objects(pos, elapsed)
 					object:remove()
 				end
 			end
-			
+
 		end
 	end
 	return true
@@ -92,7 +92,7 @@ minetest.register_node("tubelib_addons1:funnel", {
 		local inv = meta:get_inventory()
 		inv:set_size('main', 16)
 	end,
-	
+
 	after_place_node = function(pos, placer)
 		tubelib.add_node(pos, "tubelib_addons1:funnel")
 		local meta = minetest.get_meta(pos)
@@ -102,7 +102,7 @@ minetest.register_node("tubelib_addons1:funnel", {
 
 	on_timer = scan_for_objects,
 	on_rotate = screwdriver.disallow,
-		
+
 	can_dig = function(pos, player)
 		if minetest.is_protected(pos, player:get_player_name()) then
 			return false
@@ -115,7 +115,7 @@ minetest.register_node("tubelib_addons1:funnel", {
 	after_dig_node = function(pos, oldnode, oldmetadata, digger)
 		tubelib.remove_node(pos)
 	end,
-	
+
 	allow_metadata_inventory_put = allow_metadata_inventory_put,
 	allow_metadata_inventory_take = allow_metadata_inventory_take,
 
@@ -125,6 +125,7 @@ minetest.register_node("tubelib_addons1:funnel", {
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 
@@ -148,7 +149,7 @@ tubelib.register_node("tubelib_addons1:funnel", {}, {
 		local meta = minetest.get_meta(pos)
 		return tubelib.put_item(meta, "main", item)
 	end,
-	
+
 	on_recv_message = function(pos, topic, payload)
 		if topic == "state" then
 			local meta = minetest.get_meta(pos)
@@ -161,6 +162,4 @@ tubelib.register_node("tubelib_addons1:funnel", {}, {
 		minetest.get_node_timer(pos):start(1)
 	end,
 
-})	
-
-
+})

--- a/tubelib_addons1/grinder.lua
+++ b/tubelib_addons1/grinder.lua
@@ -9,9 +9,9 @@
 	See LICENSE.txt for more information
 
 	grinder.lua
-	
+
 	Grinding Cobble to Gravel
-	
+
 ]]--
 
 -- Load support for I18n
@@ -153,8 +153,8 @@ minetest.register_node("tubelib_addons1:grinder", {
 		State:on_dig_node(pos, node, player)
 		tubelib.remove_node(pos)
 	end,
-	
-	
+
+
 	on_rotate = screwdriver.disallow,
 	on_timer = keep_running,
 	on_receive_fields = on_receive_fields,
@@ -168,6 +168,7 @@ minetest.register_node("tubelib_addons1:grinder", {
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 
@@ -185,7 +186,7 @@ minetest.register_node("tubelib_addons1:grinder_active", {
 				length = 1.0,
 			},
 		},
-		
+
 		'tubelib_front.png',
 		"tubelib_front.png",
 		"tubelib_front.png",
@@ -209,6 +210,7 @@ minetest.register_node("tubelib_addons1:grinder_active", {
 	groups = {crumbly=0, not_in_creative_inventory=1},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_node("tubelib_addons1:grinder_defect", {
@@ -244,7 +246,7 @@ minetest.register_node("tubelib_addons1:grinder_defect", {
 	after_dig_node = function(pos, oldnode, oldmetadata, digger)
 		tubelib.remove_node(pos)
 	end,
-	
+
 	on_rotate = screwdriver.disallow,
 	allow_metadata_inventory_put = allow_metadata_inventory_put,
 	allow_metadata_inventory_move = allow_metadata_inventory_move,
@@ -256,6 +258,7 @@ minetest.register_node("tubelib_addons1:grinder_defect", {
 	groups = {choppy=2, cracky=2, crumbly=2, not_in_creative_inventory=1},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_craft({
@@ -268,7 +271,7 @@ minetest.register_craft({
 })
 
 
-tubelib.register_node("tubelib_addons1:grinder", 
+tubelib.register_node("tubelib_addons1:grinder",
 	{"tubelib_addons1:grinder_active", "tubelib_addons1:grinder_defect"}, {
 	on_pull_stack = function(pos, side)
 		return tubelib.get_stack(M(pos), "dst")
@@ -296,7 +299,7 @@ tubelib.register_node("tubelib_addons1:grinder",
 	on_node_repair = function(pos)
 		return State:on_node_repair(pos)
 	end,
-})	
+})
 
 
 if minetest.global_exists("unified_inventory") then
@@ -472,5 +475,3 @@ for _,v in pairs({
 end
 
 if minetest.get_modpath("jacaranda") then tubelib.add_grinder_recipe({input="jacaranda:trunk", output = "jacaranda:blossom_leaves 8"}) end
-
-

--- a/tubelib_addons1/harvester.lua
+++ b/tubelib_addons1/harvester.lua
@@ -7,11 +7,11 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	harvester.lua
-	
+
 	Harvester machine to chop wood, leaves and harvest farming crops and flowers.
-	
+
 	The machine is able to harvest an square area of up to 33x33 blocks (radius = 16).
 	The base node has to be placed in the middle of the harvesting area.
 	The Harvester processes one node every 6 seconds.
@@ -54,14 +54,14 @@ local function formspec(self, pos, meta)
 	end
 	local radius = Radius2Idx[this.radius] or 2
 	local altitude = Altitude2Idx[this.altitude or START_HEIGHT] or 11
-	
+
 	return "size[9,8]"..
 	default.gui_bg..
 	default.gui_bg_img..
 	default.gui_slots..
-	"dropdown[0,0;1.5;radius;4,6,8,10,12,14,16;"..radius.."]".. 
+	"dropdown[0,0;1.5;radius;4,6,8,10,12,14,16;"..radius.."]"..
 	"label[1.6,0.2;"..S("Area radius").."]"..
-	"dropdown[0,1;1.5;altitude;-2,-1,0,1,2,4,6,8,10,14,18;"..altitude.."]".. 
+	"dropdown[0,1;1.5;altitude;-2,-1,0,1,2,4,6,8,10,14,18;"..altitude.."]"..
 	"label[1.6,1.2;"..S("Altitude ").."]"..
 	"checkbox[0,2;endless;"..S("Run endless")..";"..endless.."]"..
 	"list[context;main;5,0;4,4;]"..
@@ -111,7 +111,7 @@ local function gen_working_steps()
 		end
 	end
 	return t
-end		
+end
 
 local WorkingSteps = gen_working_steps()
 
@@ -167,7 +167,7 @@ end
 local function remove_or_replace_node(this, pos, inv, node, order)
 	local next_pos = table.copy(pos)
 	next_pos.y = next_pos.y - 1
-	
+
 	-- Not enough space in the inventory
 	if not inv:room_for_item("main", ItemStack(node.name)) then
 		return false
@@ -179,7 +179,7 @@ local function remove_or_replace_node(this, pos, inv, node, order)
 		this.num_items = this.num_items + 1
 		if is_plantable_ground(next_node) and order.plant then  -- hit the ground?
 			minetest.set_node(pos, {name=order.plant, paramtype2 = "wallmounted", param2=1})
-			if order.t1 ~= nil then 
+			if order.t1 ~= nil then
 				-- We have to simulate "on_place" and start the timer by hand
 				-- because the after_place_node function checks player rights and can't therefore
 				-- be used.
@@ -189,7 +189,7 @@ local function remove_or_replace_node(this, pos, inv, node, order)
 		end
 	end
 	return true
-end	
+end
 
 -- check the fuel level and return false if empty
 local function check_fuel(pos, this, meta)
@@ -244,7 +244,7 @@ local function harvest_field(this, meta)
 				if not minetest.is_protected(pos, this.owner) and not remove_or_replace_node(this, pos, inv, node, order) then
 					return false
 				end
-			else 	
+			else
 				return true	-- hit the ground
 			end
 		end
@@ -261,20 +261,20 @@ local function not_blocked(pos, this, meta)
 	end
 	return true
 end
-	
+
 -- move the "harvesting copter" to the next pos and harvest the field below
 local function keep_running(pos, elapsed)
 	if tubelib.data_not_corrupted(pos) then
 		local meta = M(pos)
 		local this = minetest.deserialize(meta:get_string("this"))
 		this.num_items = 0
-		
+
 		if not_blocked(pos, this, meta) then
 			if check_fuel(pos, this, meta) then
 				if calc_new_pos(pos, this, meta) then
 					if harvest_field(this, meta) then
 						meta:set_string("this", minetest.serialize(this))
-						meta:set_string("infotext", 
+						meta:set_string("infotext",
 							S("Tubelib Harvester").." "..this.number..
 							S(": running (")..this.idx.."/"..this.max..")")
 						State:keep_running(pos, meta, COUNTDOWN_TICKS, this.num_items)
@@ -291,8 +291,8 @@ local function keep_running(pos, elapsed)
 		return State:is_active(meta)
 	end
 	return false
-end	
-	
+end
+
 
 local function on_receive_fields(pos, formname, fields, player)
 	if minetest.is_protected(pos, player:get_player_name()) then
@@ -302,7 +302,7 @@ local function on_receive_fields(pos, formname, fields, player)
 	local this = minetest.deserialize(meta:get_string("this"))
 	local radius = this.radius
 	local altitude = this.altitude or START_HEIGHT
-	
+
 	if fields.radius ~= nil then
 		radius = tonumber(fields.radius)
 	end
@@ -321,12 +321,12 @@ local function on_receive_fields(pos, formname, fields, player)
 		meta:set_string("this", minetest.serialize(this))
 		State:stop(pos, meta)
 	end
-	
+
 	if fields.endless ~= nil then
 		this.endless = fields.endless == "true" and 1 or 0
 	end
 	meta:set_string("this", minetest.serialize(this))
-	
+
 	State:state_button_event(pos, fields)
 end
 
@@ -371,7 +371,7 @@ minetest.register_node("tubelib_addons1:harvester_base", {
 		State:on_dig_node(pos, node, player)
 		tubelib.remove_node(pos)
 	end,
-	
+
 	on_rotate = screwdriver.disallow,
 	on_receive_fields = on_receive_fields,
 	on_timer = keep_running,
@@ -384,6 +384,7 @@ minetest.register_node("tubelib_addons1:harvester_base", {
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_node("tubelib_addons1:harvester_defect", {
@@ -400,7 +401,7 @@ minetest.register_node("tubelib_addons1:harvester_defect", {
 		inv:set_size('main', 16)
 		inv:set_size('fuel', 1)
 	end,
-	
+
 	after_place_node = function(pos, placer)
 		local number = tubelib.add_node(pos, "tubelib_addons1:harvester_base")
 		local this = {
@@ -441,6 +442,7 @@ minetest.register_node("tubelib_addons1:harvester_defect", {
 	groups = {choppy=2, cracky=2, crumbly=2, not_in_creative_inventory=1},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 
@@ -474,7 +476,7 @@ tubelib.register_node("tubelib_addons1:harvester_base", {"tubelib_addons1:harves
 		if topic == "fuel" then
 			return tubelib.fuelstate(M(pos), "fuel")
 		end
-		
+
 		local resp = State:on_receive_message(pos, topic, payload)
 		if resp then
 			return resp
@@ -488,7 +490,7 @@ tubelib.register_node("tubelib_addons1:harvester_base", {"tubelib_addons1:harves
 	on_node_repair = function(pos)
 		return State:on_node_repair(pos)
 	end,
-})	
+})
 
 
 -- update to v0.08
@@ -506,4 +508,3 @@ minetest.register_lbm({
 		end
 	end
 })
-

--- a/tubelib_addons1/liquidsampler.lua
+++ b/tubelib_addons1/liquidsampler.lua
@@ -7,9 +7,9 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	liquidsampler.lua
-	
+
 ]]--
 
 -- Load support for I18n
@@ -59,12 +59,12 @@ local function get_pos(pos, facedir, side)
 	facedir = (facedir + offs[side]) % 4
 	local dir = minetest.facedir_to_dir(facedir)
 	return vector.add(dst_pos, dir)
-end	
+end
 
 
 local function test_liquid(node)
 	local liquiddef = bucket.liquids[node.name]
-	if liquiddef ~= nil	and liquiddef.itemname ~= nil and 
+	if liquiddef ~= nil	and liquiddef.itemname ~= nil and
 			node.name == liquiddef.source then
 		return liquiddef.itemname
 	end
@@ -165,7 +165,7 @@ minetest.register_node("tubelib_addons1:liquidsampler", {
 		State:on_dig_node(pos, node, player)
 		tubelib.remove_node(pos)
 	end,
-	
+
 	on_rotate = screwdriver.disallow,
 	on_timer = keep_running,
 	on_receive_fields = on_receive_fields,
@@ -179,6 +179,7 @@ minetest.register_node("tubelib_addons1:liquidsampler", {
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_node("tubelib_addons1:liquidsampler_active", {
@@ -218,6 +219,7 @@ minetest.register_node("tubelib_addons1:liquidsampler_active", {
 	groups = {crumbly=0, not_in_creative_inventory=1},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_node("tubelib_addons1:liquidsampler_defect", {
@@ -268,6 +270,7 @@ minetest.register_node("tubelib_addons1:liquidsampler_defect", {
 	groups = {choppy=2, cracky=2, crumbly=2, not_in_creative_inventory=1},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_craft({
@@ -279,7 +282,7 @@ minetest.register_craft({
 	},
 })
 
-tubelib.register_node("tubelib_addons1:liquidsampler", 
+tubelib.register_node("tubelib_addons1:liquidsampler",
 	{"tubelib_addons1:liquidsampler_active", "tubelib_addons1:liquidsampler_defect"}, {
 	invalid_sides = {"L"},
 	on_pull_item = function(pos, side)
@@ -305,4 +308,4 @@ tubelib.register_node("tubelib_addons1:liquidsampler",
 	on_node_repair = function(pos)
 		return State:on_node_repair(pos)
 	end,
-})	
+})

--- a/tubelib_addons1/pusher_fast.lua
+++ b/tubelib_addons1/pusher_fast.lua
@@ -9,14 +9,14 @@
 	See LICENSE.txt for more information
 
 	pusher_fast.lua:
-	
+
 	Fast pusher for push/pull operation of StackItems from chests or other
 	inventory/server nodes to tubes or other inventory/server nodes.
-	
+
 	The Pusher is based on the class NodeStates and supports the following messages:
 	 - topic = "on", payload  = nil
 	 - topic = "off", payload  = nil
-	 - topic = "state", payload  = nil, 
+	 - topic = "state", payload  = nil,
 	   response is "running", "stopped", "standby", "blocked", or "not supported"
 
 ]]--
@@ -78,7 +78,7 @@ local function keep_running(pos, elapsed)
 		return State:is_active(meta)
 	end
 	return false
-end	
+end
 
 minetest.register_node("tubelib_addons1:pusher_fast", {
 	description = S("Fast Pusher"),
@@ -109,7 +109,7 @@ minetest.register_node("tubelib_addons1:pusher_fast", {
 		State:on_dig_node(pos, node, player)
 		tubelib.remove_node(pos)
 	end,
-	
+
 	on_timer = keep_running,
 	on_rotate = screwdriver.disallow,
 
@@ -119,6 +119,7 @@ minetest.register_node("tubelib_addons1:pusher_fast", {
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 
@@ -175,19 +176,20 @@ minetest.register_node("tubelib_addons1:pusher_fast_active", {
 			State:stop(pos, M(pos))
 		end
 	end,
-	
+
 	on_timer = keep_running,
 	on_rotate = screwdriver.disallow,
 
 	diggable = false,
 	can_dig = function() return false end,
-	
+
 	paramtype = "light",
 	sunlight_propagates = true,
 	paramtype2 = "facedir",
 	groups = {crumbly=0, not_in_creative_inventory=1},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_node("tubelib_addons1:pusher_fast_defect", {
@@ -213,7 +215,7 @@ minetest.register_node("tubelib_addons1:pusher_fast_defect", {
 	after_dig_node = function(pos)
 		tubelib.remove_node(pos)
 	end,
-	
+
 	on_timer = keep_running,
 	on_rotate = screwdriver.disallow,
 
@@ -223,6 +225,7 @@ minetest.register_node("tubelib_addons1:pusher_fast_defect", {
 	groups = {choppy=2, cracky=2, crumbly=2, not_in_creative_inventory=1},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 
@@ -235,14 +238,14 @@ minetest.register_craft({
 	},
 })
 
-tubelib.register_node("tubelib_addons1:pusher_fast", 
+tubelib.register_node("tubelib_addons1:pusher_fast",
 	{"tubelib_addons1:pusher_fast_active", "tubelib_addons1:pusher_fast_defect"}, {
 	on_pull_item = nil,  		-- pusher has no inventory
 	on_push_item = nil,			-- pusher has no inventory
 	on_unpull_item = nil,		-- pusher has no inventory
 	is_pusher = true,           -- is a pulling/pushing node
 	valid_sides = {"R","L"},
-	
+
 	on_recv_message = function(pos, topic, payload)
 		local resp = State:on_receive_message(pos, topic, payload)
 		if resp then
@@ -257,4 +260,4 @@ tubelib.register_node("tubelib_addons1:pusher_fast",
 	on_node_repair = function(pos)
 		return State:on_node_repair(pos)
 	end,
-})	
+})

--- a/tubelib_addons1/quarry.lua
+++ b/tubelib_addons1/quarry.lua
@@ -7,11 +7,11 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	quarry.lua
-	
+
 	Quarry machine to dig stones and other ground blocks.
-	
+
 	The Quarry digs a hole 5x5 blocks large and up to 100 blocks deep.
 	It starts at the given level (0 is same level as the quarry block,
 	1 is one level higher and so on)) and goes down to the given depth number.
@@ -35,7 +35,7 @@ local COUNTDOWN_TICKS = 5
 
 local Side2Facedir = {F=0, R=1, B=2, L=3, D=4, U=5}
 local Depth2Idx = {[1]=1 ,[2]=2, [3]=3, [5]=4, [10]=5, [15]=6, [20]=7, [25]=8, [50]=9, [100]=10}
-local Level2Idx = {[2]=1, [1]=2, [0]=3, [-1]=4, [-2]=5, [-3]=6, 
+local Level2Idx = {[2]=1, [1]=2, [0]=3, [-1]=4, [-2]=5, [-3]=6,
 				   [-5]=7, [-10]=8, [-15]=9, [-20]=10}
 
 local function formspec(self, pos, meta)
@@ -52,14 +52,14 @@ local function formspec(self, pos, meta)
 	else
 		fuel = 0
 	end
-	
+
 	return "size[9,8]"..
 	default.gui_bg..
 	default.gui_bg_img..
 	default.gui_slots..
-	"dropdown[0,0;1.5;level;2,1,0,-1,-2,-3,-5,-10,-15,-20;"..Level2Idx[start_level].."]".. 
+	"dropdown[0,0;1.5;level;2,1,0,-1,-2,-3,-5,-10,-15,-20;"..Level2Idx[start_level].."]"..
 	"label[1.6,0.2;"..S("Start level").."]"..
-	"dropdown[0,1;1.5;depth;1,2,3,5,10,15,20,25,50,100;"..Depth2Idx[depth].."]".. 
+	"dropdown[0,1;1.5;depth;1,2,3,5,10,15,20,25,50,100;"..Depth2Idx[depth].."]"..
 	"label[1.6,1.2;"..S("Digging depth").."]"..
 	"checkbox[0,2;endless;"..S("Run endless")..";"..endless.."]"..
 	"list[context;main;5,0;4,4;]"..
@@ -95,7 +95,7 @@ local function get_pos(pos, facedir, side, steps)
 	facedir = (facedir + Side2Facedir[side]) % 4
 	local dir = vector.multiply(minetest.facedir_to_dir(facedir), steps or 1)
 	return vector.add(pos, dir)
-end	
+end
 
 local function get_node_lvm(pos)
 	local node = minetest.get_node_or_nil(pos)
@@ -144,7 +144,7 @@ local function get_next_pos(pos, facedir, dir)
 	return vector.add(pos, core.facedir_to_dir(facedir))
 end
 
-local function skip_the_air(pos, curr_level, facedir) 
+local function skip_the_air(pos, curr_level, facedir)
 	local pos1, pos2, lPos
 	pos1 = get_pos(pos, facedir, "F", 2)
 	pos2 = get_pos(pos, facedir, "B", 2)
@@ -157,9 +157,9 @@ local function skip_the_air(pos, curr_level, facedir)
 		pos1.y = pos1.y - 1
 		pos2.y = pos2.y - 1
 	end
-	return pos2.y 
+	return pos2.y
 end
-	
+
 local function quarry_next_node(pos, meta)
 	-- check fuel
 	local fuel = meta:get_int("fuel") or 0
@@ -178,8 +178,8 @@ local function quarry_next_node(pos, meta)
 	else
 		fuel = fuel - 1
 	end
-	meta:set_int("fuel", fuel) 
-	
+	meta:set_int("fuel", fuel)
+
 	local idx = meta:get_int("idx")
 	if idx == 0 then idx = 1 end
 	local facedir = minetest.get_node(pos).param2
@@ -188,10 +188,10 @@ local function quarry_next_node(pos, meta)
 	local start_y = pos.y + meta:get_int("start_level")
 	local stop_y = pos.y + meta:get_int("start_level") - meta:get_int("max_levels") + 1
 	local quarry_pos = P(meta:get_string("quarry_pos"))
-	
+
 	if quarry_pos == nil then  -- start at the beginning?
 		quarry_pos = get_pos(pos, facedir, "L")
-		local y = skip_the_air(quarry_pos, start_y, facedir) 
+		local y = skip_the_air(quarry_pos, start_y, facedir)
 		if y < stop_y then -- below the base line?
 			meta:set_int("idx", 1)
 			meta:set_string("quarry_pos", nil)
@@ -263,7 +263,7 @@ local function on_receive_fields(pos, formname, fields, player)
 		return
 	end
 	local meta = M(pos)
-	
+
 	local max_levels = meta:get_int("max_levels")
 	if fields.depth then
 		max_levels = tonumber(fields.depth)
@@ -273,7 +273,7 @@ local function on_receive_fields(pos, formname, fields, player)
 		meta:set_int("max_levels", max_levels)
 		State:stop(pos, meta)
 	end
-	
+
 	local start_level = meta:get_int("start_level") or 0
 	if fields.level ~= nil then
 		start_level = tonumber(fields.level)
@@ -283,13 +283,13 @@ local function on_receive_fields(pos, formname, fields, player)
 		meta:set_int("start_level", start_level)
 		State:stop(pos, meta)
 	end
-	
+
 	local endless = meta:get_int("endless") or 0
 	if fields.endless ~= nil then
 		endless = fields.endless == "true" and 1 or 0
 	end
 	meta:set_int("endless", endless)
-	
+
 	State:state_button_event(pos, fields)
 end
 
@@ -330,7 +330,7 @@ minetest.register_node("tubelib_addons1:quarry", {
 		State:on_dig_node(pos, node, player)
 		tubelib.remove_node(pos)
 	end,
-	
+
 	on_rotate = screwdriver.disallow,
 	on_receive_fields = on_receive_fields,
 	on_timer = keep_running,
@@ -343,6 +343,7 @@ minetest.register_node("tubelib_addons1:quarry", {
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_node("tubelib_addons1:quarry_active", {
@@ -377,13 +378,14 @@ minetest.register_node("tubelib_addons1:quarry_active", {
 
 	allow_metadata_inventory_put = allow_metadata_inventory_put,
 	allow_metadata_inventory_take = allow_metadata_inventory_take,
-	
+
 	paramtype = "light",
 	sunlight_propagates = true,
 	paramtype2 = "facedir",
 	groups = {crumbly=0, not_in_creative_inventory=1},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_node("tubelib_addons1:quarry_defect", {
@@ -434,6 +436,7 @@ minetest.register_node("tubelib_addons1:quarry_defect", {
 	groups = {choppy=2, cracky=2, crumbly=2, not_in_creative_inventory=1},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_craft({
@@ -446,7 +449,7 @@ minetest.register_craft({
 })
 
 
-tubelib.register_node("tubelib_addons1:quarry", 
+tubelib.register_node("tubelib_addons1:quarry",
 	{"tubelib_addons1:quarry_active", "tubelib_addons1:quarry_defect"}, {
 	invalid_sides = {"L"},
 	on_pull_item = function(pos, side)
@@ -465,7 +468,7 @@ tubelib.register_node("tubelib_addons1:quarry",
 		if topic == "fuel" then
 			return tubelib.fuelstate(M(pos), "fuel")
 		end
-		
+
 		local resp = State:on_receive_message(pos, topic, payload)
 		if resp then
 			return resp
@@ -482,5 +485,4 @@ tubelib.register_node("tubelib_addons1:quarry",
 	on_node_repair = function(pos)
 		return State:on_node_repair(pos)
 	end,
-})	
-
+})

--- a/tubelib_addons1/reformer.lua
+++ b/tubelib_addons1/reformer.lua
@@ -226,6 +226,7 @@ minetest.register_node("tubelib_addons1:reformer", {
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_metal_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_node("tubelib_addons1:reformer_defect", {
@@ -298,6 +299,7 @@ minetest.register_node("tubelib_addons1:reformer_defect", {
 	groups = {choppy=2, cracky=2, crumbly=2, not_in_creative_inventory=1},
 	is_ground_content = false,
 	sounds = default.node_sound_metal_defaults(),
+	on_blast = function() end,
 })
 
 
@@ -319,6 +321,7 @@ minetest.register_node("tubelib_addons1:reformer_top", {
 	groups = {crumbly=0, not_in_creative_inventory=1},
 	is_ground_content = false,
 	pointable = false,
+	on_blast = function() end,
 })
 
 minetest.register_craftitem("tubelib_addons1:biofuel", {

--- a/tubelib_addons2/accesscontrol.lua
+++ b/tubelib_addons2/accesscontrol.lua
@@ -9,7 +9,7 @@
 	See LICENSE.txt for more information
 
 	accesscontrol.lua:
-	
+
 ]]--
 
 -- Load support for I18n
@@ -129,19 +129,20 @@ minetest.register_node("tubelib_addons2:accesscontrol", {
 			end
 		end
 	end,
-	
+
 	after_dig_node = function(pos)
 		tubelib.remove_node(pos)
 	end,
-	
+
 	on_timer = switch_off,
-	
+
 	paramtype = "light",
 	sunlight_propagates = true,
 	paramtype2 = "facedir",
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_metal_defaults(),
+	on_blast = function() end,
 })
 
 
@@ -161,4 +162,4 @@ tubelib.register_node("tubelib_addons2:accesscontrol", {}, {
 			return true
 		end
 	end,
-})		
+})

--- a/tubelib_addons2/ceilinglamp.lua
+++ b/tubelib_addons2/ceilinglamp.lua
@@ -9,7 +9,7 @@
 	See LICENSE.txt for more information
 
 	ceilinglamp.lua:
-	
+
 ]]--
 
 -- Load support for I18n
@@ -18,7 +18,7 @@ local S = tubelib_addons2.S
 local function switch_on(pos, node)
 	node.name = "tubelib_addons2:ceilinglamp_on"
 	minetest.swap_node(pos, node)
-end	
+end
 
 local function switch_off(pos, node)
 	node.name = "tubelib_addons2:ceilinglamp"
@@ -26,7 +26,7 @@ local function switch_off(pos, node)
 	local pos1 = {x=pos.x-5, y=pos.y-5, z=pos.z-5}
 	local pos2 = {x=pos.x+5, y=pos.y+5, z=pos.z+5}
 	minetest.fix_light(pos1, pos2)
-end	
+end
 
 minetest.register_node("tubelib_addons2:ceilinglamp", {
 	description = S("Tubelib Ceiling Lamp"),
@@ -69,12 +69,13 @@ minetest.register_node("tubelib_addons2:ceilinglamp", {
 	end,
 
 	paramtype = "light",
-	light_source = 0,	
+	light_source = 0,
 	sunlight_propagates = true,
 	paramtype2 = "wallmounted",
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_glass_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_node("tubelib_addons2:ceilinglamp_on", {
@@ -100,7 +101,7 @@ minetest.register_node("tubelib_addons2:ceilinglamp_on", {
 		wall_bottom = {-5/16, -8/16, -5/16,  5/16, -5/16,  5/16},
 		wall_side =   {-8/16, -5/16, -5/16, -5/16,  5/16,  5/16}
 	},
-	
+
 	on_rightclick = function(pos, node, clicker)
 		if not minetest.is_protected(pos, clicker:get_player_name()) then
 			switch_off(pos, node)
@@ -108,12 +109,13 @@ minetest.register_node("tubelib_addons2:ceilinglamp_on", {
 	end,
 
 	paramtype = "light",
-	light_source = 12,	
+	light_source = 12,
 	sunlight_propagates = true,
 	paramtype2 = "wallmounted",
 	groups = {crumbly=0, not_in_creative_inventory=1},
 	is_ground_content = false,
 	sounds = default.node_sound_glass_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_craft({
@@ -131,4 +133,4 @@ tubelib.register_node("tubelib_addons2:ceilinglamp", {"tubelib_addons2:ceilingla
 			switch_off(pos, node)
 		end
 	end,
-})		
+})

--- a/tubelib_addons2/colorlamp.lua
+++ b/tubelib_addons2/colorlamp.lua
@@ -9,7 +9,7 @@
 	See LICENSE.txt for more information
 
 	colorlamp.lua:
-	
+
 ]]--
 
 -- Load support for I18n
@@ -32,7 +32,7 @@ local function switch_node(pos, num, player)
 			meta:set_int("color", num)
 		end
 	end
-end	
+end
 
 minetest.register_node("tubelib_addons2:lamp", {
 	description = S("Tubelib Color Lamp"),
@@ -45,7 +45,7 @@ minetest.register_node("tubelib_addons2:lamp", {
 		switch_node(pos, "", placer)
 		meta:set_string("formspec", "size[3,2]"..
 		"label[0,0;Select color]"..
-		"dropdown[0,0.5;3;type;"..sColor..";1]".. 
+		"dropdown[0,0.5;3;type;"..sColor..";1]"..
 		"button_exit[0.5,1.5;2,1;exit;"..S("Save").."]")
 		meta:set_int("color", 1)
 	end,
@@ -59,7 +59,7 @@ minetest.register_node("tubelib_addons2:lamp", {
 			meta:set_string("formspec", nil, player)
 		end
 	end,
-	
+
 	on_rightclick = function(pos, node, clicker)
 		local meta = minetest.get_meta(pos)
 		switch_node(pos, meta:get_int("color"), clicker)
@@ -74,6 +74,7 @@ minetest.register_node("tubelib_addons2:lamp", {
 	sounds = default.node_sound_stone_defaults(),
 	groups = {choppy=2, cracky=1},
 	is_ground_content = false,
+	on_blast = function() end,
 })
 
 tubelib.register_node("tubelib_addons2:lamp", {}, {
@@ -85,7 +86,7 @@ tubelib.register_node("tubelib_addons2:lamp", {}, {
 			switch_node(pos, "", nil)
 		end
 	end,
-})	
+})
 
 
 minetest.register_craft({
@@ -113,7 +114,7 @@ for idx,color in ipairs(tColors) do
 				meta:set_string("formspec", nil)
 			end
 		end,
-		
+
 		on_rightclick = function(pos, node, clicker)
 			switch_node(pos, "", clicker)
 		end,
@@ -123,10 +124,11 @@ for idx,color in ipairs(tColors) do
 		end,
 
 		paramtype = 'light',
-		light_source = minetest.LIGHT_MAX,	
+		light_source = minetest.LIGHT_MAX,
 		sounds = default.node_sound_stone_defaults(),
 		groups = {choppy=2, cracky=1, not_in_creative_inventory=1},
 		is_ground_content = false,
-		drop = "tubelib_addons2:lamp"
+		drop = "tubelib_addons2:lamp",
+    	on_blast = function() end,
 	})
 end

--- a/tubelib_addons2/colorlamp_ud.lua
+++ b/tubelib_addons2/colorlamp_ud.lua
@@ -9,7 +9,7 @@
 	See LICENSE.txt for more information
 
 	colorlamp_ud.lua which requires the mod unifieddyes:
-	
+
 ]]--
 
 -- Load support for I18n
@@ -20,14 +20,14 @@ local function switch_on(pos, node, player)
 		node.name = "tubelib_addons2:lamp_on"
 		minetest.swap_node(pos, node)
 	end
-end	
+end
 
 local function switch_off(pos, node, player)
 	if player == nil or not minetest.is_protected(pos, player:get_player_name()) then
 		node.name = "tubelib_addons2:lamp_off"
 		minetest.swap_node(pos, node)
 	end
-end	
+end
 
 minetest.register_node("tubelib_addons2:lamp_off", {
 	description = S("Tubelib Color Lamp"),
@@ -49,7 +49,7 @@ minetest.register_node("tubelib_addons2:lamp_off", {
 
 	on_construct = unifieddyes.on_construct,
 	on_dig = unifieddyes.on_dig,
-	
+
 	paramtype = "light",
 	paramtype2 = "color",
 	palette = "unifieddyes_palette_extended.png",
@@ -58,7 +58,8 @@ minetest.register_node("tubelib_addons2:lamp_off", {
 	sounds = default.node_sound_stone_defaults(),
 	groups = {choppy=2, cracky=1, ud_param2_colorable = 1},
 	is_ground_content = false,
-	drop = "tubelib_addons2:lamp_off"
+	drop = "tubelib_addons2:lamp_off",
+	on_blast = function() end,
 })
 
 
@@ -73,19 +74,20 @@ minetest.register_node("tubelib_addons2:lamp_on", {
 	palette = "unifieddyes_palette_extended.png",
 	sounds = default.node_sound_stone_defaults(),
 	groups = {choppy=2, cracky=1, not_in_creative_inventory=1, ud_param2_colorable = 1},
-	
+
 	on_construct = unifieddyes.on_construct,
 	after_place_node = unifieddyes.recolor_on_place,
-	
+
 	after_dig_node = function(pos, oldnode, oldmetadata, digger)
 		tubelib.remove_node(pos)
 		unifieddyes.after_dig_node(pos, oldnode, oldmetadata, digger)
 	end,
-   
+
 	on_dig = unifieddyes.on_dig,
-	light_source = minetest.LIGHT_MAX,	
+	light_source = minetest.LIGHT_MAX,
 	is_ground_content = false,
-	drop = "tubelib_addons2:lamp_off"
+	drop = "tubelib_addons2:lamp_off",
+	on_blast = function() end,
 })
 
 tubelib.register_node("tubelib_addons2:lamp_off", {"tubelib_addons2:lamp_on"}, {
@@ -98,7 +100,7 @@ tubelib.register_node("tubelib_addons2:lamp_off", {"tubelib_addons2:lamp_on"}, {
 			switch_off(pos, node, nil)
 		end
 	end,
-})	
+})
 
 minetest.register_craft({
 	type = "shapeless",
@@ -117,7 +119,8 @@ for idx=1,12 do
 		paramtype = 'light',
 		groups = {choppy=2, cracky=1, not_in_creative_inventory=1},
 		is_ground_content = false,
-		drop = "tubelib_addons2:lamp_off"
+		drop = "tubelib_addons2:lamp_off",
+		on_blast = function() end,
 	})
 end
 
@@ -127,10 +130,10 @@ minetest.register_lbm({
 	name = "tubelib_addons2:update",
 	nodenames = {
 		"tubelib_addons2:lamp",
-		"tubelib_addons2:lamp1", "tubelib_addons2:lamp2", "tubelib_addons2:lamp3", 
-		"tubelib_addons2:lamp4", "tubelib_addons2:lamp5", "tubelib_addons2:lamp6", 
-		"tubelib_addons2:lamp7", "tubelib_addons2:lamp8", "tubelib_addons2:lamp9", 
-		"tubelib_addons2:lamp10", "tubelib_addons2:lamp11", "tubelib_addons2:lamp12", 
+		"tubelib_addons2:lamp1", "tubelib_addons2:lamp2", "tubelib_addons2:lamp3",
+		"tubelib_addons2:lamp4", "tubelib_addons2:lamp5", "tubelib_addons2:lamp6",
+		"tubelib_addons2:lamp7", "tubelib_addons2:lamp8", "tubelib_addons2:lamp9",
+		"tubelib_addons2:lamp10", "tubelib_addons2:lamp11", "tubelib_addons2:lamp12",
 	},
 	run_at_every_load = true,
 	action = function(pos, node)
@@ -150,4 +153,3 @@ minetest.register_lbm({
 		meta:set_string("infotext", S("Tubelib Color Lamp").." "..number)
 	end
 })
-

--- a/tubelib_addons2/doorblock.lua
+++ b/tubelib_addons2/doorblock.lua
@@ -9,7 +9,7 @@
 	See LICENSE.txt for more information
 
 	doorblock.lua:
-	
+
 ]]--
 
 -- Load support for I18n
@@ -18,7 +18,7 @@ local S = tubelib_addons2.S
 local sTextures = "Gate Wood,Aspen Wood,Jungle Wood,Pine Wood,"..
                   "Cobblestone,Sandstone,Stone,Desert Sandstone,"..
                   "Copper,Steel,Tin,Coral,"..
-				  "Glas,Obsidian Glas"  
+				  "Glas,Obsidian Glas"
 
 local tTextures = {
 	["Gate Wood"]=1, ["Aspen Wood"]=2, ["Jungle Wood"]=3, ["Pine Wood"]=4,
@@ -26,7 +26,7 @@ local tTextures = {
 	["Copper"]=9, ["Steel"]=10, ["Tin"]=11, ["Coral"]=12,
 	["Glas"]=13, ["Obsidian Glas"]=14,
 }
-	
+
 local tPgns = {"tubelib_addon2_door.png", "default_aspen_wood.png", "default_junglewood.png", "default_pine_wood.png",
 	"default_cobble.png", "default_sandstone.png", "default_stone.png", "default_desert_sandstone.png",
 	"default_copper_block.png", "default_steel_block.png", "default_tin_block.png", "default_coral_skeleton.png",
@@ -60,7 +60,7 @@ for idx,pgn in ipairs(tPgns) do
 			meta:set_string("infotext", S("Tubelib Door Block").." "..number)
 			meta:set_string("formspec", "size[3,2]"..
 			"label[0,0;"..S("Select texture").."]"..
-			"dropdown[0,0.5;3;type;"..sTextures..";1]".. 
+			"dropdown[0,0.5;3;type;"..sTextures..";1]"..
 			"button_exit[0.5,1.5;2,1;exit;"..S("Save").."]")
 		end,
 
@@ -76,7 +76,7 @@ for idx,pgn in ipairs(tPgns) do
 				meta:set_string("formspec", nil)
 			end
 		end,
-		
+
 		after_dig_node = function(pos, oldnode, oldmetadata)
 			tubelib.remove_node(pos)
 		end,
@@ -89,10 +89,11 @@ for idx,pgn in ipairs(tPgns) do
 		groups = {cracky=2, choppy=2, crumbly=2, not_in_creative_inventory=not_in_inventory},
 		is_ground_content = false,
 		drop = "tubelib_addons2:doorblock1",
+		on_blast = function() end,
 	})
 
 	not_in_inventory = 1
-	
+
 	tubelib.register_node("tubelib_addons2:doorblock"..idx, {}, {
 		on_recv_message = function(pos, topic, payload)
 			local node = minetest.get_node(pos)
@@ -110,7 +111,7 @@ for idx,pgn in ipairs(tPgns) do
 				end
 			end
 		end,
-	})		
+	})
 end
 
 minetest.register_craft({

--- a/tubelib_addons2/gateblock.lua
+++ b/tubelib_addons2/gateblock.lua
@@ -9,7 +9,7 @@
 	See LICENSE.txt for more information
 
 	gateblock.lua:
-	
+
 ]]--
 
 -- Load support for I18n
@@ -19,9 +19,9 @@ local NUM_TEXTURES = 20
 
 local sTextures = "Wood,Aspen Wood,Jungle Wood,Pine Wood,"..
                   "Cobblestone,Sandstone,Stone,Desert Sandstone,"..
-				  "Desert Stone,Silver Sandstone,Mossy Cobble,Desert Cobble,"..  
+				  "Desert Stone,Silver Sandstone,Mossy Cobble,Desert Cobble,"..
                   "Copper,Steel,Tin,Coral,"..
-				  "Glas,Obsidian Glas,Ice,Gate Wood"  
+				  "Glas,Obsidian Glas,Ice,Gate Wood"
 
 local tTextures = {
 	["Wood"]=1, ["Aspen Wood"]=2, ["Jungle Wood"]=3, ["Pine Wood"]=4,
@@ -30,7 +30,7 @@ local tTextures = {
 	["Copper"]=13, ["Steel"]=14, ["Tin"]=15, ["Coral"]=16,
 	["Glas"]=17, ["Obsidian Glas"]=18, ["Ice"]=19, ["Gate Wood"]=20,
 }
-	
+
 local tPgns = {"default_wood.png", "default_aspen_wood.png", "default_junglewood.png", "default_pine_wood.png",
 	"default_cobble.png", "default_sandstone.png", "default_stone.png", "default_desert_sandstone.png",
 	"default_desert_stone_block.png", "default_silver_sandstone.png", "default_mossycobble.png", "default_desert_cobble.png",
@@ -49,7 +49,7 @@ for idx,pgn in ipairs(tPgns) do
 			meta:set_string("infotext", S("Tubelib Gate Block").." "..number)
 			meta:set_string("formspec", "size[3,2]"..
 			"label[0,0;Select texture]"..
-			"dropdown[0,0.5;3;type;"..sTextures..";"..NUM_TEXTURES.."]".. 
+			"dropdown[0,0.5;3;type;"..sTextures..";"..NUM_TEXTURES.."]"..
 			"button_exit[0.5,1.5;2,1;exit;"..S("Save").."]")
 		end,
 
@@ -65,7 +65,7 @@ for idx,pgn in ipairs(tPgns) do
 				meta:set_string("formspec", nil)
 			end
 		end,
-		
+
 		after_dig_node = function(pos, oldnode, oldmetadata)
 			tubelib.remove_node(pos)
 		end,
@@ -78,6 +78,7 @@ for idx,pgn in ipairs(tPgns) do
 		groups = {cracky=2, choppy=2, crumbly=2, not_in_creative_inventory = idx == NUM_TEXTURES and 0 or 1},
 		is_ground_content = false,
 		drop = "tubelib_addons2:gateblock1",
+		on_blast = function() end,
 	})
 
 	tubelib.register_node("tubelib_addons2:gateblock"..idx, {}, {
@@ -97,7 +98,7 @@ for idx,pgn in ipairs(tPgns) do
 				end
 			end
 		end,
-	})		
+	})
 end
 
 minetest.register_craft({

--- a/tubelib_addons2/industriallamp.lua
+++ b/tubelib_addons2/industriallamp.lua
@@ -9,7 +9,7 @@
 	See LICENSE.txt for more information
 
 	industriallamp.lua:
-	
+
 ]]--
 
 -- Load support for I18n
@@ -20,7 +20,7 @@ local function switch_on(pos, node)
 		node.name = node.name.."_on"
 		minetest.swap_node(pos, node)
 	end
-end	
+end
 
 local function switch_off(pos, node)
 	if string.sub(node.name, -3) == "_on" then
@@ -30,7 +30,7 @@ local function switch_off(pos, node)
 		local pos2 = {x=pos.x+5, y=pos.y+5, z=pos.z+5}
 		minetest.fix_light(pos1, pos2)
 	end
-end	
+end
 
 local function register_lamp(tbl)
 	local num, tiles, tiles_on, node_box, size = tbl.num, tbl.tiles, tbl.tiles_on, tbl.node_box, tbl.size
@@ -40,14 +40,14 @@ local function register_lamp(tbl)
 		drawtype = "nodebox",
 		node_box = node_box,
 		inventory_image = 'tubelib_addons2_industriallamp_inv'..num..'.png',
-		
+
 		selection_box = {
 			type = "wallmounted",
 			wall_top =    {-size.x, 0.5 - size.y, -size.z, size.x, 0.5, size.z},
 			wall_bottom = {-size.x, -0.5, -size.z, size.x, -0.5 + size.y, size.z},
 			wall_side =   {-0.5, -size.z, size.x, -0.5 + size.y, size.z, -size.x},
 		},
-	
+
 		after_place_node = function(pos, placer)
 			local number = tubelib.add_node(pos, "tubelib_addons2:industriallamp"..num)
 			local meta = minetest.get_meta(pos)
@@ -66,12 +66,13 @@ local function register_lamp(tbl)
 		end,
 
 		paramtype = "light",
-		light_source = 0,	
+		light_source = 0,
 		sunlight_propagates = true,
 		paramtype2 = "wallmounted",
 		groups = {choppy=2, cracky=2, crumbly=2},
 		is_ground_content = false,
 		sounds = default.node_sound_glass_defaults(),
+		on_blast = function() end,
 	})
 
 	minetest.register_node("tubelib_addons2:industriallamp"..num.."_on", {
@@ -79,20 +80,20 @@ local function register_lamp(tbl)
 		tiles = tiles_on,
 		drawtype = "nodebox",
 		node_box = node_box,
-		
+
 		selection_box = {
 			type = "wallmounted",
 			wall_top =    {-size.x, 0.5 - size.y, -size.z, size.x, 0.5, size.z},
 			wall_bottom = {-size.x, -0.5, -size.z, size.x, -0.5 + size.y, size.z},
 			wall_side =   {-0.5, -size.z, size.x, -0.5 + size.y, size.z, -size.x},
 		},
-	
+
 		after_place_node = function(pos, placer)
 			local number = tubelib.add_node(pos, "tubelib_addons2:industriallamp"..num)
 			local meta = minetest.get_meta(pos)
 			meta:set_string("infotext", S("Tubelib Industrial Lamp").." "..num..": "..number)
 		end,
-		
+
 		on_rightclick = function(pos, node, clicker)
 			if not minetest.is_protected(pos, clicker:get_player_name()) then
 				node.name = "tubelib_addons2:industriallamp"..num
@@ -108,13 +109,14 @@ local function register_lamp(tbl)
 		end,
 
 		paramtype = "light",
-		light_source = minetest.LIGHT_MAX,	
+		light_source = minetest.LIGHT_MAX,
 		sunlight_propagates = true,
 		paramtype2 = "wallmounted",
 		groups = {choppy=2, cracky=2, crumbly=2, not_in_creative_inventory=1},
 		drop = "tubelib_addons2:industriallamp"..num,
 		is_ground_content = false,
 		sounds = default.node_sound_glass_defaults(),
+		on_blast = function() end,
 	})
 
 	tubelib.register_node("tubelib_addons2:industriallamp"..num, {"tubelib_addons2:industriallamp"..num.."_on"}, {
@@ -149,7 +151,7 @@ minetest.register_craft({
 
 
 register_lamp({
-	num = 1, 
+	num = 1,
 	tiles = {
 		-- up, down, right, left, back, front
 		'tubelib_addons2_industriallamp1.png',
@@ -178,9 +180,9 @@ register_lamp({
 	},
 	size = {x = 8/16, y = 7/32, z = 3/32}
 })
-	
+
 register_lamp({
-	num = 2, 
+	num = 2,
 	tiles = {
 		-- up, down, right, left, back, front
 		'tubelib_addons2_industriallamp2.png',
@@ -209,4 +211,3 @@ register_lamp({
 	},
 	size = {x = 8/32, y = 8/32, z = 5/32}
 })
-	

--- a/tubelib_addons2/invisiblelamp.lua
+++ b/tubelib_addons2/invisiblelamp.lua
@@ -9,7 +9,7 @@
 	See LICENSE.txt for more information
 
 	invisiblelamp.lua:
-	
+
 ]]--
 
 -- Load support for I18n
@@ -18,7 +18,7 @@ local S = tubelib_addons2.S
 local function switch_on(pos, node)
 	node.name = "tubelib_addons2:invisiblelamp_on"
 	minetest.swap_node(pos, node)
-end	
+end
 
 local function switch_off(pos, node)
 	node.name = "tubelib_addons2:invisiblelamp"
@@ -26,14 +26,14 @@ local function switch_off(pos, node)
 	local pos1 = {x=pos.x-5, y=pos.y-5, z=pos.z-5}
 	local pos2 = {x=pos.x+5, y=pos.y+5, z=pos.z+5}
 	minetest.fix_light(pos1, pos2)
-end	
+end
 
 minetest.register_node("tubelib_addons2:invisiblelamp", {
 	description = S("Tubelib Invisible Lamp"),
 	drawtype = "glasslike_framed_optional",
 	tiles = {"tubelib_addons2_invisiblelamp.png"},
 	inventory_image = 'tubelib_addons2_invisiblelamp_inventory.png',
-	
+
 	after_place_node = function(pos, placer)
 		local number = tubelib.add_node(pos, "tubelib_addons2:invisiblelamp")
 		local meta = minetest.get_meta(pos)
@@ -57,13 +57,14 @@ minetest.register_node("tubelib_addons2:invisiblelamp", {
 	is_ground_content = false,
 	groups = {cracky = 3, oddly_breakable_by_hand = 3},
 	sounds = default.node_sound_glass_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_node("tubelib_addons2:invisiblelamp_on", {
 	description = S("Tubelib Invisible Lamp"),
 	drawtype = "glasslike_framed_optional",
 	tiles = {"tubelib_addons2_invisiblelamp.png"},
-	
+
 	on_rightclick = function(pos, node, clicker)
 		if not minetest.is_protected(pos, clicker:get_player_name()) then
 			switch_off(pos, node)
@@ -73,7 +74,7 @@ minetest.register_node("tubelib_addons2:invisiblelamp_on", {
 	after_dig_node = function(pos)
 		tubelib.remove_node(pos)
 	end,
-	
+
 	paramtype = "light",
 	light_source = minetest.LIGHT_MAX,
 	sunlight_propagates = true,
@@ -82,6 +83,7 @@ minetest.register_node("tubelib_addons2:invisiblelamp_on", {
 	drop = "tubelib_addons2:invisiblelamp",
 	groups = {cracky = 3, oddly_breakable_by_hand = 3, not_in_creative_inventory=1},
 	sounds = default.node_sound_glass_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_craft({
@@ -102,4 +104,4 @@ tubelib.register_node("tubelib_addons2:invisiblelamp", {"tubelib_addons2:invisib
 			switch_off(pos, node)
 		end
 	end,
-})		
+})

--- a/tubelib_addons2/logic_not.lua
+++ b/tubelib_addons2/logic_not.lua
@@ -9,7 +9,7 @@
 	See LICENSE.txt for more information
 
 	logic_not.lua:
-	
+
 ]]--
 
 -- Load support for I18n
@@ -20,7 +20,7 @@ local function formspec(meta)
 	return "size[7,5]"..
 		"field[0.5,2;6,1;number;"..S("Destination node numbers")..";"..numbers.."]" ..
 		"button_exit[1,3;2,1;exit;"..S("Save").."]"
-end	
+end
 
 minetest.register_node("tubelib_addons2:logic_not", {
 	description = S("Tubelib Logic Not"),
@@ -46,7 +46,7 @@ minetest.register_node("tubelib_addons2:logic_not", {
 		if owner ~= player:get_player_name() then
 			return
 		end
-		
+
 		if tubelib.check_numbers(fields.number) then
 			meta:set_string("numbers", fields.number)
 			local own_number = meta:get_string("own_number")
@@ -54,7 +54,7 @@ minetest.register_node("tubelib_addons2:logic_not", {
 			meta:set_string("formspec", formspec(meta))
 		end
 	end,
-	
+
 	after_dig_node = function(pos)
 		tubelib.remove_node(pos)
 	end,
@@ -65,6 +65,7 @@ minetest.register_node("tubelib_addons2:logic_not", {
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_stone_defaults(),
+	on_blast = function() end,
 })
 
 
@@ -96,4 +97,4 @@ tubelib.register_node("tubelib_addons2:logic_not", {}, {
 			end
 		end
 	end,
-})		
+})

--- a/tubelib_addons2/mesecons_converter.lua
+++ b/tubelib_addons2/mesecons_converter.lua
@@ -9,7 +9,7 @@
 	See LICENSE.txt for more information
 
 	mesecons_converter.lua:
-	
+
 ]]--
 
 -- Load support for I18n
@@ -22,7 +22,7 @@ local function formspec(meta)
 	return "size[7,5]"..
 		"field[0.5,2;6,1;number;"..S("Destination node numbers")..";"..numbers.."]" ..
 		"button_exit[1,3;2,1;exit;"..S("Save").."]"
-end	
+end
 
 local function send_message(pos, topic, payload)
 	local meta = minetest.get_meta(pos)
@@ -71,20 +71,20 @@ minetest.register_node("tubelib_addons2:mesecons_converter", {
 		if owner ~= player:get_player_name() then
 			return
 		end
-		
+
 		if tubelib.check_numbers(fields.number) then
 			meta:set_string("numbers", fields.number)
 			local own_number = meta:get_string("own_number")
 			meta:set_string("infotext", S("Tubelib Mesecons Converter").." "..own_number..S(": connected with").." "..fields.number)
 			meta:set_string("formspec", formspec(meta))
 		end
-		
+
 		local timer = minetest.get_node_timer(pos)
 		if not timer:is_started() then
 			timer:start(1)
 		end
 	end,
-	
+
 	mesecons = {
 		receptor = {
 			state = mesecon.state.off,
@@ -109,7 +109,7 @@ minetest.register_node("tubelib_addons2:mesecons_converter", {
 			end,
 		}
 	},
-	
+
 	on_timer = function(pos,elapsed)
 		if tubelib.data_not_corrupted(pos) then
 			local meta = minetest.get_meta(pos)
@@ -118,7 +118,7 @@ minetest.register_node("tubelib_addons2:mesecons_converter", {
 		end
 		return false
 	end,
-	
+
 	after_dig_node = function(pos)
 		tubelib.remove_node(pos)
 	end,
@@ -129,6 +129,7 @@ minetest.register_node("tubelib_addons2:mesecons_converter", {
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_stone_defaults(),
+	on_blast = function() end,
 })
 
 
@@ -154,4 +155,4 @@ tubelib.register_node("tubelib_addons2:mesecons_converter", {}, {
 			return true
 		end
 	end,
-})		
+})

--- a/tubelib_addons2/repeater.lua
+++ b/tubelib_addons2/repeater.lua
@@ -9,7 +9,7 @@
 	See LICENSE.txt for more information
 
 	repeater.lua:
-	
+
 ]]--
 
 -- Load support for I18n
@@ -22,7 +22,7 @@ local function formspec(meta)
 	return "size[7,5]"..
 		"field[0.5,2;6,1;number;"..S("Destination node numbers")..";"..numbers.."]" ..
 		"button_exit[1,3;2,1;exit;"..S("Save").."]"
-end	
+end
 
 minetest.register_node("tubelib_addons2:repeater", {
 	description = S("Tubelib Repeater"),
@@ -50,20 +50,20 @@ minetest.register_node("tubelib_addons2:repeater", {
 		if owner ~= player:get_player_name() then
 			return
 		end
-		
+
 		if tubelib.check_numbers(fields.number) then
 			meta:set_string("numbers", fields.number)
 			local own_number = meta:get_string("own_number")
 			meta:set_string("infotext", S("Tubelib Repeater").." "..own_number..S(": connected with").." "..fields.number)
 			meta:set_string("formspec", formspec(meta))
 		end
-		
+
 		local timer = minetest.get_node_timer(pos)
 		if not timer:is_started() then
 			timer:start(1)
 		end
 	end,
-	
+
 	on_timer = function(pos,elapsed)
 		if tubelib.data_not_corrupted(pos) then
 			local meta = minetest.get_meta(pos)
@@ -72,7 +72,7 @@ minetest.register_node("tubelib_addons2:repeater", {
 		end
 		return false
 	end,
-	
+
 	after_dig_node = function(pos)
 		tubelib.remove_node(pos)
 	end,
@@ -83,6 +83,7 @@ minetest.register_node("tubelib_addons2:repeater", {
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_stone_defaults(),
+	on_blast = function() end,
 })
 
 
@@ -120,4 +121,4 @@ tubelib.register_node("tubelib_addons2:repeater", {}, {
 	on_node_load = function(pos)
 		minetest.get_node_timer(pos):start(1)
 	end,
-})		
+})

--- a/tubelib_addons2/sequencer.lua
+++ b/tubelib_addons2/sequencer.lua
@@ -9,7 +9,7 @@
 	See LICENSE.txt for more information
 
 	sequencer.lua:
-	
+
 ]]--
 
 -- Load support for I18n
@@ -30,7 +30,7 @@ local function formspec(state, rules, endless)
 		default.gui_bg_img..
 		default.gui_slots..
 		"label[0,0;Number(s)]label[2.1,0;"..S("Command").."]label[6.4,0;Offset/s]"}
-		
+
 	for idx, rule in ipairs(rules or {}) do
 		tbl[#tbl+1] = "field[0.2,"..(-0.2+idx)..";2,1;num"..idx..";;"..(rule.num or "").."]"
 		tbl[#tbl+1] = "dropdown[2,"..(-0.4+idx)..";3.9,1;act"..idx..";"..sAction..";"..(rule.act or "").."]"
@@ -39,7 +39,7 @@ local function formspec(state, rules, endless)
 	tbl[#tbl+1] = "checkbox[0,8.5;endless;"..S("Run endless")..";"..endless.."]"
 	tbl[#tbl+1] = "image_button[5,8.5;1,1;".. tubelib.state_button(state) ..";button;]"
 	tbl[#tbl+1] = "button[6.2,8.5;1.5,1;"..S("help")..";help]"
-	
+
 	return table.concat(tbl)
 end
 
@@ -89,7 +89,7 @@ local function restart_timer(pos, time)
 	if type(time) == "number" then
 		timer:start(time)
 	end
-end	
+end
 
 local function check_rules(pos, elapsed)
 	if tubelib.data_not_corrupted(pos) then
@@ -151,19 +151,19 @@ local function 	on_receive_fields(pos, formname, fields, player)
 		if minetest.is_protected(pos, player:get_player_name()) then
 			return
 		end
-		
+
 		if fields.help ~= nil then
 			meta:set_string("formspec", formspec_help())
 			return
 		end
-		
+
 		local endless = meta:get_int("endless") or 0
 		if fields.endless ~= nil then
 			endless = fields.endless == "true" and 1 or 0
 			meta:set_int("index", 1)
 		end
 		meta:set_int("endless", endless)
-		
+
 		local rules = minetest.deserialize(meta:get_string("rules"))
 		if fields.exit ~= nil then
 			meta:set_string("formspec", formspec(tubelib.state(running), rules, endless))
@@ -206,7 +206,7 @@ minetest.register_node("tubelib_addons2:sequencer", {
 		'tubelib_front.png',
 		'tubelib_front.png^tubelib_addons2_sequencer.png',
 	},
-	
+
 	after_place_node = function(pos, placer)
 		local meta = minetest.get_meta(pos)
 		local number = tubelib.add_node(pos, "tubelib_addons2:sequencer")
@@ -225,7 +225,7 @@ minetest.register_node("tubelib_addons2:sequencer", {
 	end,
 
 	on_receive_fields = on_receive_fields,
-	
+
 	on_dig = function(pos, node, puncher, pointed_thing)
 		if minetest.is_protected(pos, puncher:get_player_name()) then
 			return
@@ -237,15 +237,16 @@ minetest.register_node("tubelib_addons2:sequencer", {
 			tubelib.remove_node(pos)
 		end
 	end,
-	
+
 	on_timer = check_rules,
-	
+
 	paramtype = "light",
 	sunlight_propagates = true,
 	paramtype2 = "facedir",
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_stone_defaults(),
+	on_blast = function() end,
 })
 
 
@@ -276,4 +277,4 @@ tubelib.register_node("tubelib_addons2:sequencer", {}, {
 			minetest.get_node_timer(pos):start(1)
 		end
 	end,
-})		
+})

--- a/tubelib_addons2/streetlamp.lua
+++ b/tubelib_addons2/streetlamp.lua
@@ -9,7 +9,7 @@
 	See LICENSE.txt for more information
 
 	streetlamp.lua:
-	
+
 ]]--
 
 -- Load support for I18n
@@ -18,12 +18,12 @@ local S = tubelib_addons2.S
 local function switch_on(pos, node)
 	node.name = "tubelib_addons2:streetlamp_on"
 	minetest.swap_node(pos, node)
-end	
+end
 
 local function switch_off(pos, node)
 	node.name = "tubelib_addons2:streetlamp"
 	minetest.swap_node(pos, node)
-end	
+end
 
 minetest.register_node("tubelib_addons2:streetlamp", {
 	description = S("Tubelib Street Lamp"),
@@ -66,12 +66,13 @@ minetest.register_node("tubelib_addons2:streetlamp", {
 	end,
 
 	paramtype = "light",
-	light_source = 0,	
+	light_source = 0,
 	sunlight_propagates = true,
 	paramtype2 = "facedir",
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_glass_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_node("tubelib_addons2:streetlamp_on", {
@@ -95,7 +96,7 @@ minetest.register_node("tubelib_addons2:streetlamp_on", {
 		type = "fixed",
 		fixed = {-8/16, -8/16, -8/16,   8/16, 8/16, 8/16},
 	},
-	
+
 	on_rightclick = function(pos, node, clicker)
 		if not minetest.is_protected(pos, clicker:get_player_name()) then
 			switch_off(pos, node)
@@ -103,12 +104,13 @@ minetest.register_node("tubelib_addons2:streetlamp_on", {
 	end,
 
 	paramtype = "light",
-	light_source = minetest.LIGHT_MAX,	
+	light_source = minetest.LIGHT_MAX,
 	sunlight_propagates = true,
 	paramtype2 = "facedir",
 	groups = {crumbly=0, not_in_creative_inventory=1},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_craft({
@@ -127,5 +129,5 @@ tubelib.register_node("tubelib_addons2:streetlamp", {"tubelib_addons2:streetlamp
 			switch_off(pos, node)
 		end
 	end,
-})		
+})
 --------------------------------------------------------------- tubelib.

--- a/tubelib_addons2/timer.lua
+++ b/tubelib_addons2/timer.lua
@@ -9,7 +9,7 @@
 	See LICENSE.txt for more information
 
 	timer.lua:
-	
+
 ]]--
 
 -- Load support for I18n
@@ -18,9 +18,9 @@ local S = tubelib_addons2.S
 local CYCLE_TIME = 8
 
 local tTime = {
-	["00:00"] = 1, ["02:00"] = 2, ["04:00"] = 3, 
+	["00:00"] = 1, ["02:00"] = 2, ["04:00"] = 3,
 	["06:00"] = 4, ["08:00"] = 5, ["10:00"] = 6,
-	["12:00"] = 7, ["14:00"] = 8, ["16:00"] = 9, 
+	["12:00"] = 7, ["14:00"] = 8, ["16:00"] = 9,
 	["18:00"] =10, ["20:00"] =11, ["22:00"] =12,
 }
 
@@ -39,32 +39,32 @@ local function formspec(events, numbers, actions)
 		default.gui_bg..
 		default.gui_bg_img..
 		default.gui_slots..
-			
+
 		"label[0,0;"..S("Time").."]label[2.3,0;"..S("Number(s)").."]label[4.5,0;"..S("Command").."]"..
-		"dropdown[0,1;2,1;e1;"..sTime..";"..events[1].."]".. 
+		"dropdown[0,1;2,1;e1;"..sTime..";"..events[1].."]"..
 		"field[2.3,1.2;2,1;n1;;"..numbers[1].."]" ..
-		"dropdown[4.5,1;3,1;a1;"..sAction..";"..tAction[actions[1]].."]".. 
-		
-		"dropdown[0,2;2,1;e2;"..sTime..";"..events[2].."]".. 
+		"dropdown[4.5,1;3,1;a1;"..sAction..";"..tAction[actions[1]].."]"..
+
+		"dropdown[0,2;2,1;e2;"..sTime..";"..events[2].."]"..
 		"field[2.3,2.2;2,1;n2;;"..numbers[2].."]" ..
-		"dropdown[4.5,2;3,1;a2;"..sAction..";"..tAction[actions[2]].."]".. 
-		
-		"dropdown[0,3;2,1;e3;"..sTime..";"..events[3].."]".. 
+		"dropdown[4.5,2;3,1;a2;"..sAction..";"..tAction[actions[2]].."]"..
+
+		"dropdown[0,3;2,1;e3;"..sTime..";"..events[3].."]"..
 		"field[2.3,3.2;2,1;n3;;"..numbers[3].."]" ..
-		"dropdown[4.5,3;3,1;a3;"..sAction..";"..tAction[actions[3]].."]".. 
-		
-		"dropdown[0,4;2,1;e4;"..sTime..";"..events[4].."]".. 
+		"dropdown[4.5,3;3,1;a3;"..sAction..";"..tAction[actions[3]].."]"..
+
+		"dropdown[0,4;2,1;e4;"..sTime..";"..events[4].."]"..
 		"field[2.3,4.2;2,1;n4;;"..numbers[4].."]" ..
-		"dropdown[4.5,4;3,1;a4;"..sAction..";"..tAction[actions[4]].."]".. 
-		
-		"dropdown[0,5;2,1;e5;"..sTime..";"..events[5].."]".. 
+		"dropdown[4.5,4;3,1;a4;"..sAction..";"..tAction[actions[4]].."]"..
+
+		"dropdown[0,5;2,1;e5;"..sTime..";"..events[5].."]"..
 		"field[2.3,5.2;2,1;n5;;"..numbers[5].."]" ..
-		"dropdown[4.5,5;3,1;a5;"..sAction..";"..tAction[actions[5]].."]".. 
-		
-		"dropdown[0,6;2,1;e6;"..sTime..";"..events[6].."]".. 
+		"dropdown[4.5,5;3,1;a5;"..sAction..";"..tAction[actions[5]].."]"..
+
+		"dropdown[0,6;2,1;e6;"..sTime..";"..events[6].."]"..
 		"field[2.3,6.2;2,1;n6;;"..numbers[6].."]" ..
-		"dropdown[4.5,6;3,1;a6;"..sAction..";"..tAction[actions[6]].."]".. 
-		
+		"dropdown[4.5,6;3,1;a6;"..sAction..";"..tAction[actions[6]].."]"..
+
 		"button_exit[3,7;2,1;exit;close]"
 end
 
@@ -79,7 +79,7 @@ local function check_rules(pos,elapsed)
 		local done = minetest.deserialize(meta:get_string("done"))
 		local placer_name = meta:get_string("placer_name")
 		local number = meta:get_string("number")
-		
+
 		-- check all rules
 		for idx,act in ipairs(actions) do
 			if act ~= "" and numbers[idx] ~= "" then
@@ -94,7 +94,7 @@ local function check_rules(pos,elapsed)
 				end
 			end
 		end
-		
+
 		-- prepare for the next day
 		if hour == 23 then
 			done = {false,false,false,false,false,false}
@@ -138,7 +138,7 @@ minetest.register_node("tubelib_addons2:timer", {
 		if minetest.is_protected(pos, player:get_player_name()) then
 			return
 		end
-		
+
 		local events = minetest.deserialize(meta:get_string("events"))
 		for idx, evt in ipairs({fields.e1, fields.e2, fields.e3, fields.e4, fields.e5, fields.e6}) do
 			if evt ~= nil then
@@ -162,12 +162,12 @@ minetest.register_node("tubelib_addons2:timer", {
 			end
 		end
 		meta:set_string("actions", minetest.serialize(actions))
-	
+
 		meta:set_string("formspec", formspec(events, numbers, actions))
 		local done = {false,false,false,false,false,false}
 		meta:set_string("done",  minetest.serialize(done))
 	end,
-	
+
 	on_timer = check_rules,
 
 	after_dig_node = function(pos)
@@ -180,6 +180,7 @@ minetest.register_node("tubelib_addons2:timer", {
 	sounds = default.node_sound_stone_defaults(),
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
+	on_blast = function() end,
 })
 
 
@@ -202,4 +203,3 @@ tubelib.register_node("tubelib_addons2:timer", {}, {
 		check_rules(pos,0)
 	end,
 })
-

--- a/tubelib_addons3/chest.lua
+++ b/tubelib_addons3/chest.lua
@@ -7,9 +7,9 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	chest.lua
-	
+
 	A high performance chest
 
 ]]--
@@ -27,7 +27,7 @@ local function store_action(pos, player, action, stack)
 	local number = meta:get_string("number")
 	local item = stack:get_name().." "..stack:get_count()
 	PlayerActions[number] = {name, action, item}
-end	
+end
 
 local function send_off_command(pos)
 	local meta = minetest.get_meta(pos)
@@ -95,7 +95,7 @@ minetest.register_node("tubelib_addons3:chest", {
 		local inv = meta:get_inventory()
 		inv:set_size('main', 72)
 	end,
-	
+
 	after_place_node = function(pos, placer)
 		local meta = minetest.get_meta(pos)
 		local number = tubelib.add_node(pos, "tubelib_addons3:chest")
@@ -113,7 +113,7 @@ minetest.register_node("tubelib_addons3:chest", {
 		local inv = meta:get_inventory()
 		return inv:is_empty("main")
 	end,
-	
+
 	on_dig = function(pos, node, puncher, pointed_thing)
 		minetest.node_dig(pos, node, puncher, pointed_thing)
 		tubelib.remove_node(pos)
@@ -128,6 +128,7 @@ minetest.register_node("tubelib_addons3:chest", {
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 
@@ -164,7 +165,7 @@ tubelib.register_node("tubelib_addons3:chest", {}, {
 		local meta = minetest.get_meta(pos)
 		return tubelib.put_item(meta, "main", item)
 	end,
-	
+
 	on_recv_message = function(pos, topic, payload)
 		if topic == "state" then
 			local meta = minetest.get_meta(pos)
@@ -185,4 +186,4 @@ tubelib.register_node("tubelib_addons3:chest", {}, {
 			return "unsupported"
 		end
 	end,
-})	
+})

--- a/tubelib_addons3/chest_cart.lua
+++ b/tubelib_addons3/chest_cart.lua
@@ -7,9 +7,9 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	chest.lua
-	
+
 	A high performance chest
 
 ]]--
@@ -59,7 +59,7 @@ end
 minetest.register_node("tubelib_addons3:chest_cart", {
 	description = S("TA Chest Cart"),
 	tiles = {
-		-- up, down, right, left, back, front		
+		-- up, down, right, left, back, front
 			"tubelib_addons3_chest_cart_top.png",
 			"tubelib_addons3_chest_cart_bottom.png",
 			"tubelib_addons3_chest_cart_side.png",
@@ -83,13 +83,14 @@ minetest.register_node("tubelib_addons3:chest_cart", {
 	groups = {cracky = 2, crumbly = 2, choppy = 2},
 	node_placement_prediction = "",
 	diggable = false,
-	
+
 	on_place = minecart.on_nodecart_place,
 	on_punch = minecart.on_nodecart_punch,
 	allow_metadata_inventory_put = allow_metadata_inventory_put,
 	allow_metadata_inventory_take = allow_metadata_inventory_take,
 	on_rightclick = on_rightclick,
-	
+	on_blast = function() end,
+
 	after_place_node = function(pos, placer)
 		local inv = M(pos):get_inventory()
 		inv:set_size('main', 4)
@@ -99,14 +100,14 @@ minetest.register_node("tubelib_addons3:chest_cart", {
 			M(pos):set_string("formspec", formspec())
 		end
 	end,
-	
+
 	set_cargo = function(pos, data)
 		local inv = M(pos):get_inventory()
 		for idx, stack in ipairs(data) do
 			inv:set_stack("main", idx, stack)
 		end
 	end,
-	
+
 	get_cargo = function(pos)
 		local inv = M(pos):get_inventory()
 		local data = {}
@@ -151,7 +152,7 @@ tubelib.register_node("tubelib_addons3:chest_cart", {}, {
 		local meta = minetest.get_meta(pos)
 		return tubelib.put_item(meta, "main", item)
 	end,
-	
+
 	on_recv_message = function(pos, topic, payload)
 		if topic == "state" then
 			local meta = minetest.get_meta(pos)
@@ -160,7 +161,7 @@ tubelib.register_node("tubelib_addons3:chest_cart", {}, {
 			return "unsupported"
 		end
 	end,
-})	
+})
 
 minetest.register_craft({
 	output = "tubelib_addons3:chest_cart",

--- a/tubelib_addons3/funnel.lua
+++ b/tubelib_addons3/funnel.lua
@@ -7,11 +7,11 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	funnel.lua
 
 	A high performance funnel
-	
+
 ]]--
 
 -- Load support for I18n
@@ -58,7 +58,7 @@ local function scan_for_objects(pos, elapsed)
 					object:remove()
 				end
 			end
-			
+
 		end
 	end
 	return true
@@ -94,7 +94,7 @@ minetest.register_node("tubelib_addons3:funnel", {
 		local inv = meta:get_inventory()
 		inv:set_size('main', 16)
 	end,
-	
+
 	after_place_node = function(pos, placer)
 		tubelib.add_node(pos, "tubelib_addons3:funnel")
 		local meta = minetest.get_meta(pos)
@@ -104,7 +104,7 @@ minetest.register_node("tubelib_addons3:funnel", {
 
 	on_timer = scan_for_objects,
 	on_rotate = screwdriver.disallow,
-		
+
 	can_dig = function(pos, player)
 		if minetest.is_protected(pos, player:get_player_name()) then
 			return false
@@ -117,7 +117,7 @@ minetest.register_node("tubelib_addons3:funnel", {
 	after_dig_node = function(pos, oldnode, oldmetadata, digger)
 		tubelib.remove_node(pos)
 	end,
-	
+
 	allow_metadata_inventory_put = allow_metadata_inventory_put,
 	allow_metadata_inventory_take = allow_metadata_inventory_take,
 
@@ -127,6 +127,7 @@ minetest.register_node("tubelib_addons3:funnel", {
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 
@@ -154,7 +155,7 @@ tubelib.register_node("tubelib_addons3:funnel", {}, {
 		local meta = minetest.get_meta(pos)
 		return tubelib.put_item(meta, "main", item)
 	end,
-	
+
 	on_recv_message = function(pos, topic, payload)
 		if topic == "state" then
 			local meta = minetest.get_meta(pos)
@@ -167,6 +168,4 @@ tubelib.register_node("tubelib_addons3:funnel", {}, {
 		minetest.get_node_timer(pos):start(1)
 	end,
 
-})	
-
-
+})

--- a/tubelib_addons3/pusher.lua
+++ b/tubelib_addons3/pusher.lua
@@ -7,9 +7,9 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	pusher.lua
-	
+
 	A high performance pusher
 
 ]]--
@@ -67,7 +67,7 @@ local function keep_running(pos, elapsed)
 		return State:is_active(meta)
 	end
 	return false
-end	
+end
 
 minetest.register_node("tubelib_addons3:pusher", {
 	description = S("HighPerf Pusher"),
@@ -98,7 +98,7 @@ minetest.register_node("tubelib_addons3:pusher", {
 		State:on_dig_node(pos, node, player)
 		tubelib.remove_node(pos)
 	end,
-	
+
 	on_timer = keep_running,
 	on_rotate = screwdriver.disallow,
 
@@ -108,6 +108,7 @@ minetest.register_node("tubelib_addons3:pusher", {
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 
@@ -164,7 +165,7 @@ minetest.register_node("tubelib_addons3:pusher_active", {
 			State:stop(pos, M(pos))
 		end
 	end,
-	
+
 	on_timer = keep_running,
 	on_rotate = screwdriver.disallow,
 
@@ -177,6 +178,7 @@ minetest.register_node("tubelib_addons3:pusher_active", {
 	groups = {crumbly=0, not_in_creative_inventory=1},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_node("tubelib_addons3:pusher_defect", {
@@ -202,7 +204,7 @@ minetest.register_node("tubelib_addons3:pusher_defect", {
 	after_dig_node = function(pos)
 		tubelib.remove_node(pos)
 	end,
-	
+
 	on_timer = keep_running,
 	on_rotate = screwdriver.disallow,
 
@@ -212,6 +214,7 @@ minetest.register_node("tubelib_addons3:pusher_defect", {
 	groups = {choppy=2, cracky=2, crumbly=2, not_in_creative_inventory=1},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 
@@ -224,7 +227,7 @@ minetest.register_craft({
 	},
 })
 
-tubelib.register_node("tubelib_addons3:pusher", 
+tubelib.register_node("tubelib_addons3:pusher",
 	{"tubelib_addons3:pusher_active", "tubelib_addons3:pusher_defect"}, {
 	is_pusher = true,           -- is a pulling/pushing node
 	valid_sides = {"R","L"},
@@ -243,4 +246,4 @@ tubelib.register_node("tubelib_addons3:pusher",
 	on_node_repair = function(pos)
 		return State:on_node_repair(pos)
 	end,
-})	
+})

--- a/tubelib_addons3/pushing_chest.lua
+++ b/tubelib_addons3/pushing_chest.lua
@@ -250,6 +250,7 @@ minetest.register_node("tubelib_addons3:pushing_chest", {
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 minetest.register_node("tubelib_addons3:pushing_chest_defect", {
@@ -304,6 +305,7 @@ minetest.register_node("tubelib_addons3:pushing_chest_defect", {
 	groups = {choppy=2, cracky=2, crumbly=2, not_in_creative_inventory=1},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 

--- a/tubelib_addons3/teleporter.lua
+++ b/tubelib_addons3/teleporter.lua
@@ -7,9 +7,9 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	teleporter.lua
-	
+
 	A node, moving items to the peer teleporter node.
 
 ]]--
@@ -49,13 +49,13 @@ minetest.register_node("tubelib_addons3:teleporter", {
 			Tube:pairing(pos, fields.channel)
 		end
 	end,
-	
+
 	after_dig_node = function(pos, oldnode, oldmetadata, digger)
 		Tube:stop_pairing(pos, oldmetadata, sFormspec)
 		local tube_dir = tonumber(oldmetadata.fields.tube_dir or 0)
 		Tube:after_dig_node(pos, {tube_dir})
 	end,
-	
+
 	on_rotate = screwdriver.disallow,
 	paramtype = "light",
 	sunlight_propagates = true,
@@ -63,6 +63,7 @@ minetest.register_node("tubelib_addons3:teleporter", {
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	on_blast = function() end,
 })
 
 


### PR DESCRIPTION
Fixes https://github.com/joe7575/techpack/issues/112

Sorry, my editor likes to remove trailing whitespace every time it saves a file, please ignore.

This should be everything, but it's worth double checking.